### PR TITLE
feat: blog admin v1 with Turso and magic link auth

### DIFF
--- a/app/admin/(dashboard)/layout.tsx
+++ b/app/admin/(dashboard)/layout.tsx
@@ -1,0 +1,49 @@
+import Link from "next/link"
+import { ReactNode } from "react"
+import { logoutAction } from "@/app/admin/actions"
+import { requireAdminSession } from "@/lib/admin-auth"
+
+export const dynamic = "force-dynamic"
+
+export default async function AdminDashboardLayout({ children }: { children: ReactNode }) {
+  const session = await requireAdminSession()
+
+  return (
+    <div className="min-h-screen bg-custom-bg-primary text-custom-text-secondary">
+      <header className="border-b border-custom-text-primary/10 bg-custom-bg-secondary/70">
+        <div className="container mx-auto px-4 py-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm text-custom-text-primary/80">Painel do Blog</p>
+            <h1 className="text-xl font-semibold">Lucimeire Xavier Advocacia</h1>
+            <p className="text-xs text-custom-text-primary/60 mt-1">{session.email}</p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <Link
+              href="/admin/posts"
+              className="rounded-lg border border-custom-text-primary/20 px-3 py-2 text-sm hover:bg-custom-text-primary/10"
+            >
+              Artigos
+            </Link>
+            <Link
+              href="/admin/posts/new"
+              className="rounded-lg bg-custom-text-primary px-3 py-2 text-sm font-semibold text-custom-bg-secondary hover:opacity-90"
+            >
+              Novo artigo
+            </Link>
+            <form action={logoutAction}>
+              <button
+                type="submit"
+                className="rounded-lg border border-custom-text-primary/20 px-3 py-2 text-sm hover:bg-custom-text-primary/10"
+              >
+                Sair
+              </button>
+            </form>
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-6">{children}</main>
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/posts/[id]/edit/page.tsx
+++ b/app/admin/(dashboard)/posts/[id]/edit/page.tsx
@@ -1,0 +1,129 @@
+import Link from "next/link"
+import { publishPostAction, unpublishPostAction, updatePostAction } from "@/app/admin/actions"
+import { getDbPostById } from "@/lib/blog-repo"
+import { notFound } from "next/navigation"
+
+export const dynamic = "force-dynamic"
+
+type EditPageProps = {
+  params: Promise<{ id: string }>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function AdminEditPostPage({ params, searchParams }: EditPageProps) {
+  const { id } = await params
+  const post = await getDbPostById(id)
+  if (!post) notFound()
+
+  const q = (await searchParams) || {}
+  const error = getParam(q.error)
+  const success = getParam(q.success)
+
+  return (
+    <div className="max-w-4xl space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <h2 className="text-2xl font-bold">Editar artigo</h2>
+          <p className="text-sm text-custom-text-primary/80">ID: {post.id}</p>
+        </div>
+        <div className="flex gap-2">
+          {post.status === "published" && (
+            <Link
+              href={`/blog/${post.slug}`}
+              target="_blank"
+              className="rounded-lg border border-custom-text-primary/20 px-3 py-2 text-sm hover:bg-custom-text-primary/10"
+            >
+              Ver no site
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">{error}</div>
+      )}
+      {success && (
+        <div className="rounded-xl border border-green-400/40 bg-green-500/10 p-3 text-sm text-green-200">{success}</div>
+      )}
+
+      <form action={updatePostAction} className="space-y-4 rounded-2xl border border-custom-text-primary/10 bg-custom-bg-secondary/40 p-5">
+        <input type="hidden" name="id" value={post.id} />
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="mb-2 block">Título</span>
+            <input name="title" required defaultValue={post.title} className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            <span className="mb-2 block">Slug</span>
+            <input name="slug" required defaultValue={post.slug} className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="mb-2 block">Resumo (excerpt)</span>
+          <textarea name="excerpt" required rows={3} defaultValue={post.excerpt} className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+        </label>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="mb-2 block">Categoria</span>
+            <input name="category" required defaultValue={post.category} className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            <span className="mb-2 block">Autor</span>
+            <input name="authorName" required defaultValue={post.authorName} className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="mb-2 block">Conteúdo (Markdown/MDX)</span>
+          <textarea
+            name="contentMdx"
+            required
+            rows={20}
+            defaultValue={post.contentMdx}
+            className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2 font-mono text-sm"
+          />
+        </label>
+
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="text-sm text-custom-text-primary/70">
+            Status atual: <strong className="text-custom-text-secondary">{post.status === "published" ? "Publicado" : "Rascunho"}</strong>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <button type="submit" className="rounded-xl border border-custom-text-primary/20 px-4 py-2 text-sm hover:bg-custom-text-primary/10">
+              Salvar alterações
+            </button>
+          </div>
+        </div>
+      </form>
+
+      <div className="flex flex-wrap gap-2">
+        <form action={publishPostAction}>
+          <input type="hidden" name="id" value={post.id} />
+          <button
+            type="submit"
+            className="rounded-xl bg-green-600 px-4 py-2 text-sm font-semibold text-white hover:opacity-90"
+          >
+            Publicar
+          </button>
+        </form>
+
+        <form action={unpublishPostAction}>
+          <input type="hidden" name="id" value={post.id} />
+          <button
+            type="submit"
+            className="rounded-xl bg-amber-600 px-4 py-2 text-sm font-semibold text-white hover:opacity-90"
+          >
+            Mover para rascunho
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/posts/new/page.tsx
+++ b/app/admin/(dashboard)/posts/new/page.tsx
@@ -1,0 +1,75 @@
+import { createDraftPostAction } from "@/app/admin/actions"
+
+export const dynamic = "force-dynamic"
+
+type NewPostPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function AdminNewPostPage({ searchParams }: NewPostPageProps) {
+  const params = (await searchParams) || {}
+  const error = getParam(params.error)
+
+  return (
+    <div className="max-w-4xl space-y-4">
+      <h2 className="text-2xl font-bold">Novo artigo</h2>
+      <p className="text-sm text-custom-text-primary/80">
+        Crie um rascunho em Markdown/MDX. Você poderá publicar depois.
+      </p>
+
+      {error && (
+        <div className="rounded-xl border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">{error}</div>
+      )}
+
+      <form action={createDraftPostAction} className="space-y-4 rounded-2xl border border-custom-text-primary/10 bg-custom-bg-secondary/40 p-5">
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="mb-2 block">Título</span>
+            <input name="title" required className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            <span className="mb-2 block">Slug (opcional)</span>
+            <input name="slug" placeholder="gerado a partir do título" className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="mb-2 block">Resumo (excerpt)</span>
+          <textarea name="excerpt" required rows={3} className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+        </label>
+
+        <div className="grid gap-4 md:grid-cols-2">
+          <label className="text-sm">
+            <span className="mb-2 block">Categoria</span>
+            <input name="category" defaultValue="Direito Tributário" required className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+          <label className="text-sm">
+            <span className="mb-2 block">Autor</span>
+            <input name="authorName" defaultValue="Dra. Lucimeire Xavier" required className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2" />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="mb-2 block">Conteúdo (Markdown/MDX)</span>
+          <textarea
+            name="contentMdx"
+            required
+            rows={18}
+            placeholder="# Título do artigo"
+            className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-3 py-2 font-mono text-sm"
+          />
+        </label>
+
+        <div className="flex justify-end">
+          <button type="submit" className="rounded-xl bg-custom-text-primary px-4 py-2 font-semibold text-custom-bg-secondary">
+            Salvar rascunho
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/admin/(dashboard)/posts/page.tsx
+++ b/app/admin/(dashboard)/posts/page.tsx
@@ -1,0 +1,110 @@
+import Link from "next/link"
+import { listAdminDbPosts } from "@/lib/blog-repo"
+import { runTursoMigrations, isTursoConfigured } from "@/lib/turso"
+
+export const dynamic = "force-dynamic"
+
+type PostsPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function AdminPostsPage({ searchParams }: PostsPageProps) {
+  const params = (await searchParams) || {}
+  const error = getParam(params.error)
+  const success = getParam(params.success)
+
+  let posts = [] as Awaited<ReturnType<typeof listAdminDbPosts>>
+  if (isTursoConfigured()) {
+    await runTursoMigrations()
+    posts = await listAdminDbPosts()
+  }
+
+  return (
+    <div className="space-y-4">
+      {error && (
+        <div className="rounded-xl border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">{error}</div>
+      )}
+      {success && (
+        <div className="rounded-xl border border-green-400/40 bg-green-500/10 p-3 text-sm text-green-200">{success}</div>
+      )}
+
+      {!isTursoConfigured() ? (
+        <div className="rounded-xl border border-amber-400/40 bg-amber-500/10 p-4 text-amber-200">
+          Configure `TURSO_DATABASE_URL` e `TURSO_AUTH_TOKEN` para usar o painel.
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="rounded-xl border border-custom-text-primary/10 bg-custom-bg-secondary/40 p-6">
+          <p className="text-custom-text-primary/80 mb-4">Nenhum artigo no Turso ainda.</p>
+          <Link
+            href="/admin/posts/new"
+            className="inline-flex rounded-lg bg-custom-text-primary px-4 py-2 text-sm font-semibold text-custom-bg-secondary"
+          >
+            Criar primeiro artigo
+          </Link>
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-2xl border border-custom-text-primary/10 bg-custom-bg-secondary/40">
+          <table className="min-w-full text-sm">
+            <thead className="border-b border-custom-text-primary/10 text-custom-text-primary/80">
+              <tr>
+                <th className="px-4 py-3 text-left">Título</th>
+                <th className="px-4 py-3 text-left">Status</th>
+                <th className="px-4 py-3 text-left">Categoria</th>
+                <th className="px-4 py-3 text-left">Atualizado</th>
+                <th className="px-4 py-3 text-left">Ações</th>
+              </tr>
+            </thead>
+            <tbody>
+              {posts.map((post) => (
+                <tr key={post.id} className="border-b border-custom-text-primary/5">
+                  <td className="px-4 py-3">
+                    <div className="font-medium">{post.title}</div>
+                    <div className="text-xs text-custom-text-primary/60">/{post.slug}</div>
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-1 text-xs font-semibold ${
+                        post.status === "published"
+                          ? "bg-green-500/20 text-green-300"
+                          : "bg-amber-500/20 text-amber-300"
+                      }`}
+                    >
+                      {post.status === "published" ? "Publicado" : "Rascunho"}
+                    </span>
+                  </td>
+                  <td className="px-4 py-3">{post.category}</td>
+                  <td className="px-4 py-3">
+                    {new Date(post.updatedAt).toLocaleString("pt-BR")}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex gap-2">
+                      <Link
+                        href={`/admin/posts/${post.id}/edit`}
+                        className="rounded-lg border border-custom-text-primary/20 px-3 py-1.5 hover:bg-custom-text-primary/10"
+                      >
+                        Editar
+                      </Link>
+                      {post.status === "published" && (
+                        <Link
+                          href={`/blog/${post.slug}`}
+                          target="_blank"
+                          className="rounded-lg border border-custom-text-primary/20 px-3 py-1.5 hover:bg-custom-text-primary/10"
+                        >
+                          Ver
+                        </Link>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -1,0 +1,149 @@
+"use server"
+
+import { revalidatePath } from "next/cache"
+import { redirect } from "next/navigation"
+import { z } from "zod"
+import { clearAdminSession, requireAdminSession, sendAdminMagicLink } from "@/lib/admin-auth"
+import { createDraft, publishPost, unpublishPost, updateDraft } from "@/lib/blog-admin"
+import { getDbPostById } from "@/lib/blog-repo"
+import { isTursoConfigured, runTursoMigrations } from "@/lib/turso"
+import { slugify } from "@/lib/slug"
+
+const loginSchema = z.object({
+  email: z.string().trim().email("E-mail inválido"),
+})
+
+function redirectWithMessage(path: string, params: Record<string, string>) {
+  const usp = new URLSearchParams(params)
+  redirect(`${path}?${usp.toString()}`)
+}
+
+function parsePostForm(formData: FormData) {
+  const title = String(formData.get("title") || "").trim()
+  return {
+    title,
+    slug: slugify(String(formData.get("slug") || "").trim() || title),
+    excerpt: String(formData.get("excerpt") || "").trim(),
+    category: String(formData.get("category") || "").trim(),
+    authorName: String(formData.get("authorName") || "Dra. Lucimeire Xavier").trim(),
+    contentMdx: String(formData.get("contentMdx") || "").trim(),
+  }
+}
+
+export async function requestMagicLinkAction(formData: FormData) {
+  if (!isTursoConfigured()) {
+    redirectWithMessage("/admin/login", {
+      error: "Turso não está configurado neste ambiente.",
+    })
+  }
+
+  await runTursoMigrations()
+
+  const parsed = loginSchema.safeParse({
+    email: formData.get("email"),
+  })
+
+  if (!parsed.success) {
+    redirectWithMessage("/admin/login", {
+      error: parsed.error.issues[0]?.message || "Dados inválidos",
+    })
+  }
+
+  try {
+    await sendAdminMagicLink(parsed.data.email)
+  } catch {
+    redirectWithMessage("/admin/login", {
+      error: "Não foi possível enviar o link. Tente novamente.",
+    })
+  }
+
+  redirectWithMessage("/admin/login", {
+    success: "Se o e-mail estiver autorizado, enviamos um link de acesso.",
+  })
+}
+
+export async function logoutAction() {
+  await clearAdminSession()
+  redirect("/admin/login?success=Sessão encerrada")
+}
+
+export async function createDraftPostAction(formData: FormData) {
+  await requireAdminSession()
+  await runTursoMigrations()
+
+  try {
+    const id = await createDraft(parsePostForm(formData))
+    revalidatePath("/")
+    revalidatePath("/blog")
+    revalidatePath("/sitemap.xml")
+    redirect(`/admin/posts/${id}/edit?success=Rascunho criado com sucesso`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro ao criar rascunho"
+    redirectWithMessage("/admin/posts/new", { error: message })
+  }
+}
+
+export async function updatePostAction(formData: FormData) {
+  await requireAdminSession()
+  await runTursoMigrations()
+
+  const id = String(formData.get("id") || "")
+  if (!id) {
+    redirectWithMessage("/admin/posts", { error: "Post inválido" })
+  }
+
+  try {
+    await updateDraft(id, parsePostForm(formData))
+    const dbPost = await getDbPostById(id)
+    revalidatePath("/")
+    revalidatePath("/blog")
+    revalidatePath("/sitemap.xml")
+    if (dbPost?.slug) revalidatePath(`/blog/${dbPost.slug}`)
+    redirect(`/admin/posts/${id}/edit?success=Artigo salvo`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro ao salvar"
+    redirectWithMessage(`/admin/posts/${id}/edit`, { error: message })
+  }
+}
+
+export async function publishPostAction(formData: FormData) {
+  await requireAdminSession()
+  await runTursoMigrations()
+
+  const id = String(formData.get("id") || "")
+  if (!id) redirectWithMessage("/admin/posts", { error: "Post inválido" })
+
+  try {
+    await publishPost(id)
+    const dbPost = await getDbPostById(id)
+    revalidatePath("/")
+    revalidatePath("/blog")
+    revalidatePath("/sitemap.xml")
+    if (dbPost?.slug) revalidatePath(`/blog/${dbPost.slug}`)
+    redirect(`/admin/posts/${id}/edit?success=Artigo publicado`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro ao publicar"
+    redirectWithMessage(`/admin/posts/${id}/edit`, { error: message })
+  }
+}
+
+export async function unpublishPostAction(formData: FormData) {
+  await requireAdminSession()
+  await runTursoMigrations()
+
+  const id = String(formData.get("id") || "")
+  if (!id) redirectWithMessage("/admin/posts", { error: "Post inválido" })
+
+  try {
+    const before = await getDbPostById(id)
+    await unpublishPost(id)
+    revalidatePath("/")
+    revalidatePath("/blog")
+    revalidatePath("/sitemap.xml")
+    if (before?.slug) revalidatePath(`/blog/${before.slug}`)
+    redirect(`/admin/posts/${id}/edit?success=Artigo movido para rascunho`)
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Erro ao despublicar"
+    redirectWithMessage(`/admin/posts/${id}/edit`, { error: message })
+  }
+}

--- a/app/admin/login/page.tsx
+++ b/app/admin/login/page.tsx
@@ -1,0 +1,81 @@
+import Link from "next/link"
+import { getAdminSession } from "@/lib/admin-auth"
+import { redirect } from "next/navigation"
+import { requestMagicLinkAction } from "@/app/admin/actions"
+import { isTursoConfigured } from "@/lib/turso"
+
+export const dynamic = "force-dynamic"
+
+type LoginPageProps = {
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
+}
+
+function getParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value
+}
+
+export default async function AdminLoginPage({ searchParams }: LoginPageProps) {
+  const session = await getAdminSession()
+  if (session) {
+    redirect("/admin/posts")
+  }
+
+  const params = (await searchParams) || {}
+  const error = getParam(params.error)
+  const success = getParam(params.success)
+
+  return (
+    <div className="min-h-screen bg-custom-bg-primary text-custom-text-secondary flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-custom-bg-secondary/60 border border-custom-text-primary/20 rounded-2xl p-6 shadow-2xl">
+        <h1 className="text-2xl font-bold mb-2">Acesso ao Painel do Blog</h1>
+        <p className="text-custom-text-primary/80 mb-6">
+          Entre com seu e-mail para receber um link de acesso.
+        </p>
+
+        {!isTursoConfigured() && (
+          <div className="mb-4 rounded-xl border border-amber-400/40 bg-amber-500/10 p-3 text-sm text-amber-200">
+            Turso ainda não está configurado neste ambiente. Configure as variáveis de ambiente antes de usar o painel.
+          </div>
+        )}
+
+        {error && (
+          <div className="mb-4 rounded-xl border border-red-400/40 bg-red-500/10 p-3 text-sm text-red-200">
+            {error}
+          </div>
+        )}
+
+        {success && (
+          <div className="mb-4 rounded-xl border border-green-400/40 bg-green-500/10 p-3 text-sm text-green-200">
+            {success}
+          </div>
+        )}
+
+        <form action={requestMagicLinkAction} className="space-y-4">
+          <label className="block text-sm">
+            <span className="mb-2 block text-custom-text-primary">E-mail</span>
+            <input
+              type="email"
+              name="email"
+              required
+              placeholder="seuemail@dominio.com"
+              className="w-full rounded-xl border border-custom-text-primary/20 bg-custom-bg-primary/60 px-4 py-3 text-custom-text-secondary placeholder:text-custom-text-primary/50 focus:outline-none focus:ring-2 focus:ring-custom-text-primary/30"
+            />
+          </label>
+
+          <button
+            type="submit"
+            className="w-full rounded-xl bg-custom-text-primary px-4 py-3 font-semibold text-custom-bg-secondary hover:opacity-90 transition"
+          >
+            Enviar link de acesso
+          </button>
+        </form>
+
+        <div className="mt-6 text-sm text-custom-text-primary/70">
+          <Link href="/" className="hover:text-custom-text-secondary">
+            Voltar ao site
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/admin/magic/route.ts
+++ b/app/admin/magic/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from "next/server"
+import {
+  adminSessionCookieOptions,
+  consumeMagicToken,
+  getAdminSessionCookieName,
+  issueAdminSession,
+} from "@/lib/admin-auth"
+import { runTursoMigrations } from "@/lib/turso"
+
+export async function GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token")
+  if (!token) {
+    return NextResponse.redirect(new URL("/admin/login?error=Link inválido", request.url))
+  }
+
+  try {
+    await runTursoMigrations()
+    const payload = await consumeMagicToken(token)
+    if (!payload) {
+      return NextResponse.redirect(new URL("/admin/login?error=Link expirado ou inválido", request.url))
+    }
+
+    const issued = await issueAdminSession(payload.email)
+    const response = NextResponse.redirect(new URL("/admin/posts?success=Login realizado", request.url))
+    response.cookies.set(
+      getAdminSessionCookieName(),
+      issued.rawSession,
+      adminSessionCookieOptions(issued.expiresAt),
+    )
+    return response
+  } catch {
+    return NextResponse.redirect(new URL("/admin/login?error=Não foi possível validar o link", request.url))
+  }
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,9 @@
+import { getAdminSession } from "@/lib/admin-auth"
+import { redirect } from "next/navigation"
+
+export const dynamic = "force-dynamic"
+
+export default async function AdminRootPage() {
+  const session = await getAdminSession()
+  redirect(session ? "/admin/posts" : "/admin/login")
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -15,8 +15,10 @@ interface BlogPostPageProps {
   }>
 }
 
+export const dynamic = "force-dynamic"
+
 export async function generateStaticParams() {
-  const slugs = getAllPostSlugs()
+  const slugs = await getAllPostSlugs()
   return slugs.map((slug) => ({
     slug,
   }))
@@ -24,7 +26,7 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: BlogPostPageProps): Promise<Metadata> {
   const { slug } = await params
-  const post = getPostData(slug)
+  const post = await getPostData(slug)
 
   if (!post) {
     return {
@@ -50,7 +52,7 @@ export async function generateMetadata({ params }: BlogPostPageProps): Promise<M
 
 export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { slug } = await params
-  const post = getPostData(slug)
+  const post = await getPostData(slug)
 
   if (!post) {
     notFound()

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -14,8 +14,10 @@ export const metadata: Metadata = {
   },
 }
 
-export default function BlogPage() {
-  const posts = getSortedPostsData()
+export const dynamic = "force-dynamic"
+
+export default async function BlogPage() {
+  const posts = await getSortedPostsData()
   
   // Group posts by category
   const postsByCategory = posts.reduce((acc, post) => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -23,6 +23,8 @@ export const metadata: Metadata = createPageMetadata({
   ],
 })
 
+export const dynamic = "force-dynamic"
+
 export default function Home() {
   return (
     <div className="min-h-screen bg-custom-bg-primary relative">

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -2,7 +2,7 @@ import { MetadataRoute } from "next"
 import { getAllPostSlugs } from "@/lib/blog"
 import { SEO } from "@/lib/seo"
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = SEO.siteUrl
   const currentDate = new Date()
 
@@ -36,7 +36,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.7,
   }))
 
-  const blogPosts = getAllPostSlugs().map((slug) => ({
+  const blogPosts = (await getAllPostSlugs()).map((slug) => ({
     url: `${baseUrl}/blog/${slug}`,
     lastModified: currentDate,
     changeFrequency: 'monthly' as const,
@@ -45,3 +45,5 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   return [...staticRoutes, ...areasRoutes, ...blogPosts]
 }
+
+export default sitemap

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -4,8 +4,8 @@ import { Button } from "@/components/ui/button"
 import { getSortedPostsData } from "@/lib/blog"
 import Link from "next/link"
 
-export default function Blog() {
-  const posts = getSortedPostsData()
+export default async function Blog() {
+  const posts = await getSortedPostsData()
 
   return (
     <section id="blog" className="py-24 bg-custom-bg-secondary relative overflow-hidden">

--- a/content/blog/compliance-tributario-como-evitar-autuacoes.mdx
+++ b/content/blog/compliance-tributario-como-evitar-autuacoes.mdx
@@ -1,0 +1,147 @@
+---
+title: "Compliance Tributário: Como Evitar Autuações na Empresa"
+excerpt: "Entenda como estruturar rotinas de compliance tributário para reduzir erros, evitar autuações e melhorar a segurança fiscal da empresa."
+date: "2026-02-26"
+category: "Direito Tributário"
+author: "Dra. Lucimeire Xavier"
+published: true
+---
+
+# Compliance Tributário: Como Evitar Autuações na Empresa
+
+Compliance tributário é a organização de processos, controles e rotinas para que a empresa cumpra corretamente suas obrigações fiscais e reduza riscos de autuação.
+
+Na prática, isso significa criar uma operação mais segura para:
+
+- apurar tributos corretamente
+- entregar obrigações acessórias no prazo
+- documentar decisões fiscais
+- reduzir erros recorrentes
+- responder com mais preparo a fiscalizações
+
+## O que é compliance tributário?
+
+Compliance tributário é o conjunto de medidas internas voltadas à **conformidade fiscal e tributária** da empresa.
+
+Ele envolve aspectos jurídicos, contábeis e operacionais, com foco em prevenção de riscos.
+
+Não se trata apenas de “conferir guias”. O compliance tributário exige:
+
+- padronização de rotinas
+- controles internos
+- revisão periódica
+- alinhamento entre áreas
+- acompanhamento de mudanças legais
+
+## Por que empresas são autuadas com frequência?
+
+Muitas autuações decorrem de falhas operacionais e ausência de revisão, como:
+
+- classificação fiscal incorreta
+- apuração inadequada de tributos
+- divergência entre documentos e declarações
+- atraso em obrigações acessórias
+- interpretação equivocada de regras tributárias
+
+Mesmo empresas com boa operação podem acumular risco quando crescem sem revisar seus processos.
+
+## Principais pilares do compliance tributário
+
+### 1. Mapeamento de obrigações
+
+O primeiro passo é identificar com clareza:
+
+- quais tributos a empresa recolhe
+- quais obrigações acessórias entrega
+- quais prazos devem ser monitorados
+- quem é responsável por cada etapa
+
+Sem esse mapa, o risco de falha aumenta.
+
+### 2. Padronização de processos fiscais
+
+Rotinas críticas devem ter procedimento definido, como:
+
+- emissão de notas
+- cadastro tributário de produtos/serviços
+- conferência de documentos
+- apuração e recolhimento
+- validação antes do envio de declarações
+
+Processos padronizados reduzem erro humano e melhoram rastreabilidade.
+
+### 3. Controles e conferências periódicas
+
+Compliance tributário depende de conferência contínua, não apenas correção de problemas quando já existe fiscalização.
+
+Exemplos de controles úteis:
+
+- checklists mensais
+- revisão por amostragem
+- reconciliação entre fiscal, contábil e financeiro
+- auditorias internas periódicas
+
+### 4. Gestão documental e evidências
+
+Em uma fiscalização, a qualidade da documentação faz diferença.
+
+A empresa deve manter organização de:
+
+- notas fiscais
+- apurações
+- comprovantes de recolhimento
+- documentos de suporte
+- pareceres e decisões internas relevantes
+
+### 5. Revisão jurídica e atualização normativa
+
+Mudanças na legislação e no entendimento dos tribunais/órgãos podem impactar diretamente a rotina fiscal da empresa.
+
+Por isso, o compliance tributário precisa de revisão jurídica periódica para:
+
+- validar procedimentos
+- ajustar rotinas
+- identificar novos riscos
+- orientar decisões estratégicas
+
+## Sinais de que sua empresa precisa estruturar compliance tributário
+
+Alguns sinais comuns:
+
+1. retrabalho frequente no fiscal/contábil
+2. dúvidas recorrentes sobre tributação de operações
+3. inconsistências em declarações
+4. notificações fiscais repetidas
+5. crescimento da empresa sem revisão de processos tributários
+
+## Benefícios do compliance tributário
+
+Quando bem estruturado, o compliance tributário ajuda a:
+
+- reduzir exposição a autuações
+- melhorar previsibilidade financeira
+- aumentar segurança em decisões operacionais
+- facilitar auditorias e fiscalizações
+- apoiar crescimento com mais controle
+
+## Como começar na prática
+
+Um caminho objetivo para começar:
+
+1. Diagnosticar riscos e rotinas atuais
+2. Priorizar pontos críticos (maior impacto/maior recorrência)
+3. Definir responsáveis e prazos
+4. Criar procedimentos e checklists
+5. Revisar periodicamente com suporte especializado
+
+## Conclusão
+
+Compliance tributário não é custo de burocracia. É uma ferramenta de **gestão de risco e proteção do negócio**.
+
+Empresas que estruturam seus processos fiscais tendem a reduzir erros, responder melhor a fiscalizações e tomar decisões com mais segurança.
+
+Se você quer estruturar rotinas fiscais com mais segurança jurídica, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+
+---
+
+**Quer reduzir o risco de autuações fiscais?** A Lucimeire Xavier Advocacia atua com consultoria tributária, planejamento tributário e contencioso tributário para empresas e profissionais.

--- a/docs/seo/blog-admin-turso-v1-setup.md
+++ b/docs/seo/blog-admin-turso-v1-setup.md
@@ -1,0 +1,60 @@
+# Blog Admin V1 (Turso + Magic Link) - Setup
+
+## O que foi implementado
+
+- Painel interno em `/admin`
+- Login por magic link via e-mail
+- CRUD enxuto de artigos (rascunho/publicação)
+- Blog híbrido (Turso + arquivos MDX antigos)
+
+## Variáveis de ambiente
+
+Configure no ambiente de deploy:
+
+```bash
+TURSO_DATABASE_URL=libsql://SEU-BANCO.turso.io
+TURSO_AUTH_TOKEN=seu_token_turso
+
+RESEND_API_KEY=re_xxx
+RESEND_FROM_EMAIL=Equipe <no-reply@seudominio.com>
+
+AUTH_SECRET=uma-string-secreta-longa
+NEXTAUTH_URL=https://www.lucimeirexavieradvocacia.adv.br
+
+BLOG_ADMIN_ALLOWED_EMAILS=cliente@dominio.com,seuemail@dominio.com
+```
+
+## Como funciona a inicialização
+
+As tabelas são criadas automaticamente na primeira ação do painel (`/admin/login`, criar/editar/publicar), via migração leve em runtime.
+
+Tabelas criadas:
+
+- `blog_posts`
+- `admin_magic_tokens`
+- `admin_sessions`
+
+## Fluxo da cliente
+
+1. Acessar `/admin/login`
+2. Informar e-mail autorizado
+3. Receber link por e-mail
+4. Entrar em `/admin/posts`
+5. Criar rascunho
+6. Publicar quando estiver pronto
+
+## Observações da V1
+
+- Sem upload de imagem
+- Sem editor rico (usa Markdown/MDX em textarea)
+- Posts novos no Turso convivem com posts antigos em arquivo
+- Se um post do Turso usar o mesmo slug de um arquivo, o Turso prevalece no site público
+
+## Checklist pós-deploy
+
+- [ ] `/admin/login` abre normalmente
+- [ ] E-mail magic link é enviado (ou logado no console se Resend não configurado)
+- [ ] Login funciona com e-mail autorizado
+- [ ] `/admin/posts` lista artigos do Turso
+- [ ] Publicar artigo faz o post aparecer em `/blog`
+- [ ] `sitemap.xml` passa a incluir o slug publicado

--- a/lib/admin-auth.ts
+++ b/lib/admin-auth.ts
@@ -1,0 +1,203 @@
+import { createHash, randomBytes, randomUUID, timingSafeEqual } from "crypto"
+import { cookies, headers } from "next/headers"
+import { redirect } from "next/navigation"
+import { getTursoClient } from "@/lib/turso"
+import { sendMagicLinkEmail } from "@/lib/admin-mail"
+import { SEO } from "@/lib/seo"
+
+const SESSION_COOKIE = "blog_admin_session"
+const MAGIC_LINK_TTL_MINUTES = 15
+const SESSION_TTL_DAYS = 14
+
+function hashToken(token: string) {
+  return createHash("sha256").update(token).digest("hex")
+}
+
+function safeEq(a: string, b: string) {
+  const aBuf = Buffer.from(a)
+  const bBuf = Buffer.from(b)
+  if (aBuf.length !== bBuf.length) return false
+  return timingSafeEqual(aBuf, bBuf)
+}
+
+function allowedEmails() {
+  const raw = process.env.BLOG_ADMIN_ALLOWED_EMAILS ?? ""
+  return raw
+    .split(",")
+    .map((e) => e.trim().toLowerCase())
+    .filter(Boolean)
+}
+
+export function isEmailAllowed(email: string) {
+  const list = allowedEmails()
+  if (list.length === 0) return false
+  return list.includes(email.trim().toLowerCase())
+}
+
+function getBaseUrl() {
+  return process.env.NEXTAUTH_URL || SEO.siteUrl
+}
+
+export async function sendAdminMagicLink(email: string) {
+  const normalized = email.trim().toLowerCase()
+  if (!isEmailAllowed(normalized)) {
+    return
+  }
+
+  const client = getTursoClient()
+  if (!client) {
+    throw new Error("Turso não configurado")
+  }
+
+  const token = randomBytes(32).toString("hex")
+  const tokenHash = hashToken(token)
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + MAGIC_LINK_TTL_MINUTES * 60 * 1000).toISOString()
+
+  await client.execute({
+    sql: `INSERT INTO admin_magic_tokens (id, email, token_hash, expires_at, created_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: [randomUUID(), normalized, tokenHash, expiresAt, now.toISOString()],
+  })
+
+  const loginUrl = `${getBaseUrl()}/admin/magic?token=${token}`
+  await sendMagicLinkEmail({ email: normalized, loginUrl })
+}
+
+export async function consumeMagicToken(token: string) {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  const tokenHash = hashToken(token)
+  const res = await client.execute({
+    sql: `SELECT id, email, token_hash, expires_at, used_at FROM admin_magic_tokens WHERE token_hash = ? LIMIT 1`,
+    args: [tokenHash],
+  })
+
+  if (res.rows.length === 0) return null
+  const row = res.rows[0] as unknown as Record<string, unknown>
+  const expiresAt = String(row.expires_at)
+  const usedAt = row.used_at ? String(row.used_at) : null
+  const rowHash = String(row.token_hash)
+  if (!safeEq(rowHash, tokenHash)) return null
+  if (usedAt) return null
+  if (new Date(expiresAt).getTime() < Date.now()) return null
+
+  const nowIso = new Date().toISOString()
+  await client.execute({
+    sql: `UPDATE admin_magic_tokens SET used_at = ? WHERE id = ?`,
+    args: [nowIso, String(row.id)],
+  })
+
+  return { email: String(row.email).toLowerCase() }
+}
+
+export async function createAdminSession(email: string) {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  const rawSession = randomBytes(32).toString("hex")
+  const sessionHash = hashToken(rawSession)
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000)
+
+  await client.execute({
+    sql: `INSERT INTO admin_sessions (id, email, session_hash, expires_at, created_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: [randomUUID(), email.toLowerCase(), sessionHash, expiresAt.toISOString(), now.toISOString()],
+  })
+
+  const cookieStore = await cookies()
+  cookieStore.set(SESSION_COOKIE, rawSession, {
+    ...adminSessionCookieOptions(expiresAt),
+  })
+}
+
+export function adminSessionCookieOptions(expiresAt: Date) {
+  return {
+    httpOnly: true as const,
+    secure: true,
+    sameSite: "lax" as const,
+    path: "/",
+    expires: expiresAt,
+  }
+}
+
+export async function issueAdminSession(email: string) {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  const rawSession = randomBytes(32).toString("hex")
+  const sessionHash = hashToken(rawSession)
+  const now = new Date()
+  const expiresAt = new Date(now.getTime() + SESSION_TTL_DAYS * 24 * 60 * 60 * 1000)
+
+  await client.execute({
+    sql: `INSERT INTO admin_sessions (id, email, session_hash, expires_at, created_at)
+          VALUES (?, ?, ?, ?, ?)`,
+    args: [randomUUID(), email.toLowerCase(), sessionHash, expiresAt.toISOString(), now.toISOString()],
+  })
+
+  return { rawSession, expiresAt }
+}
+
+export function getAdminSessionCookieName() {
+  return SESSION_COOKIE
+}
+
+export async function clearAdminSession() {
+  const cookieStore = await cookies()
+  const raw = cookieStore.get(SESSION_COOKIE)?.value
+  if (raw) {
+    const client = getTursoClient()
+    if (client) {
+      await client.execute({
+        sql: `DELETE FROM admin_sessions WHERE session_hash = ?`,
+        args: [hashToken(raw)],
+      })
+    }
+  }
+  cookieStore.delete(SESSION_COOKIE)
+}
+
+export async function getAdminSession() {
+  const client = getTursoClient()
+  if (!client) return null
+  const cookieStore = await cookies()
+  const raw = cookieStore.get(SESSION_COOKIE)?.value
+  if (!raw) return null
+
+  const result = await client.execute({
+    sql: `SELECT email, expires_at FROM admin_sessions WHERE session_hash = ? LIMIT 1`,
+    args: [hashToken(raw)],
+  })
+
+  if (result.rows.length === 0) return null
+  const row = result.rows[0] as unknown as Record<string, unknown>
+  const expiresAt = String(row.expires_at)
+  if (new Date(expiresAt).getTime() < Date.now()) {
+    cookieStore.delete(SESSION_COOKIE)
+    return null
+  }
+
+  return {
+    email: String(row.email),
+    expiresAt,
+  }
+}
+
+export async function requireAdminSession() {
+  const session = await getAdminSession()
+  if (!session) {
+    redirect("/admin/login")
+  }
+  return session
+}
+
+export async function getRequestOrigin() {
+  const h = await headers()
+  const host = h.get("x-forwarded-host") || h.get("host")
+  const proto = h.get("x-forwarded-proto") || "https"
+  if (!host) return getBaseUrl()
+  return `${proto}://${host}`
+}

--- a/lib/admin-mail.ts
+++ b/lib/admin-mail.ts
@@ -1,0 +1,38 @@
+type SendMagicLinkEmailInput = {
+  email: string
+  loginUrl: string
+}
+
+export async function sendMagicLinkEmail(input: SendMagicLinkEmailInput) {
+  const apiKey = process.env.RESEND_API_KEY
+  const from = process.env.RESEND_FROM_EMAIL
+
+  if (!apiKey || !from) {
+    console.log("[admin-magic-link] Resend não configurado. Link de acesso:", input.loginUrl)
+    return
+  }
+
+  const response = await fetch("https://api.resend.com/emails", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      from,
+      to: [input.email],
+      subject: "Seu link de acesso ao painel do blog",
+      html: `
+        <p>Olá,</p>
+        <p>Use o link abaixo para acessar o painel do blog:</p>
+        <p><a href="${input.loginUrl}">${input.loginUrl}</a></p>
+        <p>Este link expira em 15 minutos.</p>
+      `,
+    }),
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new Error(`Falha ao enviar magic link: ${response.status} ${body}`)
+  }
+}

--- a/lib/blog-admin.ts
+++ b/lib/blog-admin.ts
@@ -1,0 +1,70 @@
+import { z } from "zod"
+import {
+  createDbDraftPost,
+  getDbPostById,
+  publishDbPost,
+  slugExistsInDb,
+  unpublishDbPost,
+  updateDbPost,
+} from "@/lib/blog-repo"
+import { isValidSlug, slugify } from "@/lib/slug"
+
+export const blogPostFormSchema = z.object({
+  title: z.string().trim().min(3, "Título é obrigatório"),
+  slug: z.string().trim().min(3, "Slug é obrigatório"),
+  excerpt: z.string().trim().min(10, "Resumo é obrigatório"),
+  category: z.string().trim().min(2, "Categoria é obrigatória"),
+  authorName: z.string().trim().min(2, "Autor é obrigatório"),
+  contentMdx: z.string().trim().min(20, "Conteúdo é obrigatório"),
+})
+
+export type BlogPostFormValues = z.infer<typeof blogPostFormSchema>
+
+export async function validateAndNormalizeBlogPost(
+  raw: BlogPostFormValues,
+  options?: { existingId?: string },
+) {
+  const parsed = blogPostFormSchema.parse(raw)
+  const normalizedSlug = slugify(parsed.slug || parsed.title)
+
+  if (!isValidSlug(normalizedSlug)) {
+    throw new Error("Slug inválido")
+  }
+
+  const slugTaken = await slugExistsInDb(normalizedSlug, options?.existingId)
+  if (slugTaken) {
+    throw new Error("Já existe um artigo com esse slug no banco")
+  }
+
+  return {
+    ...parsed,
+    slug: normalizedSlug,
+  }
+}
+
+export async function createDraft(values: BlogPostFormValues) {
+  const input = await validateAndNormalizeBlogPost(values)
+  return createDbDraftPost(input)
+}
+
+export async function updateDraft(id: string, values: BlogPostFormValues) {
+  const existing = await getDbPostById(id)
+  if (!existing) throw new Error("Post não encontrado")
+  const input = await validateAndNormalizeBlogPost(values, { existingId: id })
+  await updateDbPost(id, input)
+}
+
+export async function publishPost(id: string) {
+  const existing = await getDbPostById(id)
+  if (!existing) throw new Error("Post não encontrado")
+  if (!existing.title || !existing.slug || !existing.excerpt || !existing.contentMdx || !existing.category) {
+    throw new Error("Campos obrigatórios ausentes para publicação")
+  }
+  await publishDbPost(id)
+}
+
+export async function unpublishPost(id: string) {
+  const existing = await getDbPostById(id)
+  if (!existing) throw new Error("Post não encontrado")
+  await unpublishDbPost(id)
+}

--- a/lib/blog-repo.ts
+++ b/lib/blog-repo.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "crypto"
+import { getTursoClient } from "@/lib/turso"
+
+export type DbBlogPost = {
+  id: string
+  slug: string
+  title: string
+  excerpt: string
+  contentMdx: string
+  category: string
+  authorName: string
+  status: "draft" | "published"
+  publishedAt: string | null
+  createdAt: string
+  updatedAt: string
+}
+
+type BlogPostInput = {
+  slug: string
+  title: string
+  excerpt: string
+  contentMdx: string
+  category: string
+  authorName: string
+}
+
+function mapRow(row: Record<string, unknown>): DbBlogPost {
+  return {
+    id: String(row.id),
+    slug: String(row.slug),
+    title: String(row.title),
+    excerpt: String(row.excerpt),
+    contentMdx: String(row.content_mdx),
+    category: String(row.category),
+    authorName: String(row.author_name ?? "Dra. Lucimeire Xavier"),
+    status: String(row.status) as DbBlogPost["status"],
+    publishedAt: row.published_at ? String(row.published_at) : null,
+    createdAt: String(row.created_at),
+    updatedAt: String(row.updated_at),
+  }
+}
+
+export async function listPublishedDbPosts(): Promise<DbBlogPost[]> {
+  const client = getTursoClient()
+  if (!client) return []
+
+  try {
+    const result = await client.execute({
+      sql: `SELECT * FROM blog_posts WHERE status = 'published' ORDER BY COALESCE(published_at, updated_at) DESC`,
+    })
+    return result.rows.map((row) => mapRow(row as unknown as Record<string, unknown>))
+  } catch {
+    return []
+  }
+}
+
+export async function listAdminDbPosts(): Promise<DbBlogPost[]> {
+  const client = getTursoClient()
+  if (!client) return []
+
+  const result = await client.execute({
+    sql: `SELECT * FROM blog_posts ORDER BY updated_at DESC`,
+  })
+  return result.rows.map((row) => mapRow(row as unknown as Record<string, unknown>))
+}
+
+export async function getDbPostBySlug(slug: string): Promise<DbBlogPost | null> {
+  const client = getTursoClient()
+  if (!client) return null
+
+  try {
+    const result = await client.execute({
+      sql: `SELECT * FROM blog_posts WHERE slug = ? LIMIT 1`,
+      args: [slug],
+    })
+    if (result.rows.length === 0) return null
+    return mapRow(result.rows[0] as unknown as Record<string, unknown>)
+  } catch {
+    return null
+  }
+}
+
+export async function getDbPostById(id: string): Promise<DbBlogPost | null> {
+  const client = getTursoClient()
+  if (!client) return null
+  const result = await client.execute({
+    sql: `SELECT * FROM blog_posts WHERE id = ? LIMIT 1`,
+    args: [id],
+  })
+  if (result.rows.length === 0) return null
+  return mapRow(result.rows[0] as unknown as Record<string, unknown>)
+}
+
+export async function createDbDraftPost(input: BlogPostInput): Promise<string> {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  const id = randomUUID()
+  const now = new Date().toISOString()
+
+  await client.execute({
+    sql: `INSERT INTO blog_posts (
+      id, slug, title, excerpt, content_mdx, category, author_name, status, published_at, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'draft', NULL, ?, ?)`,
+    args: [
+      id,
+      input.slug,
+      input.title,
+      input.excerpt,
+      input.contentMdx,
+      input.category,
+      input.authorName,
+      now,
+      now,
+    ],
+  })
+
+  return id
+}
+
+export async function updateDbPost(id: string, input: BlogPostInput) {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  await client.execute({
+    sql: `UPDATE blog_posts
+          SET slug = ?, title = ?, excerpt = ?, content_mdx = ?, category = ?, author_name = ?, updated_at = ?
+          WHERE id = ?`,
+    args: [
+      input.slug,
+      input.title,
+      input.excerpt,
+      input.contentMdx,
+      input.category,
+      input.authorName,
+      new Date().toISOString(),
+      id,
+    ],
+  })
+}
+
+export async function publishDbPost(id: string) {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  const now = new Date().toISOString()
+  await client.execute({
+    sql: `UPDATE blog_posts
+          SET status = 'published',
+              published_at = COALESCE(published_at, ?),
+              updated_at = ?
+          WHERE id = ?`,
+    args: [now, now, id],
+  })
+}
+
+export async function unpublishDbPost(id: string) {
+  const client = getTursoClient()
+  if (!client) throw new Error("Turso não configurado")
+
+  await client.execute({
+    sql: `UPDATE blog_posts SET status = 'draft', updated_at = ? WHERE id = ?`,
+    args: [new Date().toISOString(), id],
+  })
+}
+
+export async function slugExistsInDb(slug: string, excludingId?: string) {
+  const client = getTursoClient()
+  if (!client) return false
+
+  const result = excludingId
+    ? await client.execute({
+        sql: `SELECT id FROM blog_posts WHERE slug = ? AND id != ? LIMIT 1`,
+        args: [slug, excludingId],
+      })
+    : await client.execute({
+        sql: `SELECT id FROM blog_posts WHERE slug = ? LIMIT 1`,
+        args: [slug],
+      })
+
+  return result.rows.length > 0
+}

--- a/lib/blog.ts
+++ b/lib/blog.ts
@@ -1,7 +1,8 @@
-import fs from 'fs'
-import path from 'path'
-import matter from 'gray-matter'
-import readingTime from 'reading-time'
+import fs from "fs"
+import path from "path"
+import matter from "gray-matter"
+import readingTime from "reading-time"
+import { getDbPostBySlug, listPublishedDbPosts } from "@/lib/blog-repo"
 
 export interface BlogPost {
   slug: string
@@ -13,93 +14,129 @@ export interface BlogPost {
   author?: string
   content: string
   published?: boolean
+  source?: "turso" | "file"
 }
 
-const postsDirectory = path.join(process.cwd(), 'content/blog')
+const postsDirectory = path.join(process.cwd(), "content/blog")
 
-export function getSortedPostsData(): BlogPost[] {
-  // Get file names under /content/blog
+function getFilePosts(): BlogPost[] {
   let fileNames: string[] = []
-  
+
   try {
     fileNames = fs.readdirSync(postsDirectory)
-  } catch (error) {
-    // If directory doesn't exist, return empty array
+  } catch {
     return []
   }
 
-  const allPostsData = fileNames
-    .filter((fileName) => fileName.endsWith('.mdx'))
+  return fileNames
+    .filter((fileName) => fileName.endsWith(".mdx"))
     .map((fileName) => {
-      // Remove ".mdx" from file name to get slug
-      const slug = fileName.replace(/\.mdx$/, '')
-
-      // Read markdown file as string
+      const slug = fileName.replace(/\.mdx$/, "")
       const fullPath = path.join(postsDirectory, fileName)
-      const fileContents = fs.readFileSync(fullPath, 'utf8')
-
-      // Use gray-matter to parse the post metadata section
+      const fileContents = fs.readFileSync(fullPath, "utf8")
       const { data, content } = matter(fileContents)
-
-      // Calculate reading time
       const stats = readingTime(content)
 
-      // Combine the data with the slug
       return {
         slug,
-        title: data.title || '',
-        excerpt: data.excerpt || '',
-        date: data.date || '',
+        title: data.title || "",
+        excerpt: data.excerpt || "",
+        date: data.date || "",
         readTime: stats.text,
-        category: data.category || '',
-        author: data.author || '',
+        category: data.category || "",
+        author: data.author || "",
         content,
-        published: data.published !== false, // Default to true if not specified
+        published: data.published !== false,
+        source: "file",
       } as BlogPost
     })
-    .filter((post) => post.published) // Only return published posts
-    .sort((a, b) => {
-      // Sort by date, newest first
-      return new Date(b.date).getTime() - new Date(a.date).getTime()
-    })
-
-  return allPostsData
+    .filter((post) => post.published)
 }
 
-export function getPostData(slug: string): BlogPost | null {
+async function getTursoPosts(): Promise<BlogPost[]> {
+  const dbPosts = await listPublishedDbPosts()
+
+  return dbPosts.map((post) => ({
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    date: post.publishedAt || post.updatedAt || post.createdAt,
+    readTime: readingTime(post.contentMdx).text,
+    category: post.category,
+    author: post.authorName,
+    content: post.contentMdx,
+    published: post.status === "published",
+    source: "turso",
+  }))
+}
+
+export async function getSortedPostsData(): Promise<BlogPost[]> {
+  const filePosts = getFilePosts()
+  const tursoPosts = await getTursoPosts()
+
+  const map = new Map<string, BlogPost>()
+  for (const post of filePosts) map.set(post.slug, post)
+  for (const post of tursoPosts) map.set(post.slug, post)
+
+  return Array.from(map.values()).sort((a, b) => {
+    return new Date(b.date).getTime() - new Date(a.date).getTime()
+  })
+}
+
+export async function getPostData(slug: string): Promise<BlogPost | null> {
+  const dbPost = await getDbPostBySlug(slug)
+  if (dbPost && dbPost.status === "published") {
+    return {
+      slug: dbPost.slug,
+      title: dbPost.title,
+      excerpt: dbPost.excerpt,
+      date: dbPost.publishedAt || dbPost.updatedAt || dbPost.createdAt,
+      readTime: readingTime(dbPost.contentMdx).text,
+      category: dbPost.category,
+      author: dbPost.authorName,
+      content: dbPost.contentMdx,
+      published: true,
+      source: "turso",
+    }
+  }
+
   try {
     const fullPath = path.join(postsDirectory, `${slug}.mdx`)
-    const fileContents = fs.readFileSync(fullPath, 'utf8')
-
-    // Use gray-matter to parse the post metadata section
+    const fileContents = fs.readFileSync(fullPath, "utf8")
     const { data, content } = matter(fileContents)
-
-    // Calculate reading time
     const stats = readingTime(content)
 
     return {
       slug,
-      title: data.title || '',
-      excerpt: data.excerpt || '',
-      date: data.date || '',
+      title: data.title || "",
+      excerpt: data.excerpt || "",
+      date: data.date || "",
       readTime: stats.text,
-      category: data.category || '',
-      author: data.author || '',
+      category: data.category || "",
+      author: data.author || "",
       content,
       published: data.published !== false,
+      source: "file",
     }
-  } catch (error) {
+  } catch {
     return null
   }
 }
 
-export function getAllPostSlugs(): string[] {
-  try {
-    const fileNames = fs.readdirSync(postsDirectory)
-    return fileNames
-      .filter((fileName) => fileName.endsWith('.mdx'))
-      .map((fileName) => fileName.replace(/\.mdx$/, ''))
-  } catch (error) {
-    return []
-  }
+export async function getAllPostSlugs(): Promise<string[]> {
+  const fileSlugs = (() => {
+    try {
+      const fileNames = fs.readdirSync(postsDirectory)
+      return fileNames
+        .filter((fileName) => fileName.endsWith(".mdx"))
+        .map((fileName) => fileName.replace(/\.mdx$/, ""))
+    } catch {
+      return [] as string[]
+    }
+  })()
+
+  const dbPosts = await listPublishedDbPosts()
+  const dbSlugs = dbPosts.map((p) => p.slug)
+
+  return Array.from(new Set([...fileSlugs, ...dbSlugs]))
 }

--- a/lib/slug.ts
+++ b/lib/slug.ts
@@ -1,0 +1,14 @@
+export function slugify(input: string) {
+  return input
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+}
+
+export function isValidSlug(slug: string) {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(slug)
+}

--- a/lib/turso.ts
+++ b/lib/turso.ts
@@ -1,0 +1,71 @@
+import { createClient, type Client } from "@libsql/client"
+
+let cachedClient: Client | null = null
+
+export function getTursoClient(): Client | null {
+  const url = process.env.TURSO_DATABASE_URL
+  const authToken = process.env.TURSO_AUTH_TOKEN
+
+  if (!url || !authToken) {
+    return null
+  }
+
+  if (!cachedClient) {
+    cachedClient = createClient({
+      url,
+      authToken,
+    })
+  }
+
+  return cachedClient
+}
+
+export function isTursoConfigured() {
+  return Boolean(process.env.TURSO_DATABASE_URL && process.env.TURSO_AUTH_TOKEN)
+}
+
+export async function runTursoMigrations() {
+  const client = getTursoClient()
+  if (!client) {
+    throw new Error("Turso não configurado")
+  }
+
+  const statements = [
+    `CREATE TABLE IF NOT EXISTS blog_posts (
+      id TEXT PRIMARY KEY,
+      slug TEXT NOT NULL UNIQUE,
+      title TEXT NOT NULL,
+      excerpt TEXT NOT NULL,
+      content_mdx TEXT NOT NULL,
+      category TEXT NOT NULL,
+      author_name TEXT NOT NULL DEFAULT 'Dra. Lucimeire Xavier',
+      status TEXT NOT NULL CHECK (status IN ('draft', 'published')),
+      published_at TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );`,
+    `CREATE INDEX IF NOT EXISTS idx_blog_posts_status ON blog_posts(status);`,
+    `CREATE INDEX IF NOT EXISTS idx_blog_posts_published_at ON blog_posts(published_at);`,
+    `CREATE TABLE IF NOT EXISTS admin_magic_tokens (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      token_hash TEXT NOT NULL UNIQUE,
+      expires_at TEXT NOT NULL,
+      used_at TEXT,
+      created_at TEXT NOT NULL
+    );`,
+    `CREATE INDEX IF NOT EXISTS idx_admin_magic_tokens_email ON admin_magic_tokens(email);`,
+    `CREATE TABLE IF NOT EXISTS admin_sessions (
+      id TEXT PRIMARY KEY,
+      email TEXT NOT NULL,
+      session_hash TEXT NOT NULL UNIQUE,
+      expires_at TEXT NOT NULL,
+      created_at TEXT NOT NULL
+    );`,
+    `CREATE INDEX IF NOT EXISTS idx_admin_sessions_email ON admin_sessions(email);`,
+  ]
+
+  for (const sql of statements) {
+    await client.execute(sql)
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hookform/resolvers": "^3.9.1",
+        "@libsql/client": "^0.17.0",
         "@mdx-js/loader": "^3.1.0",
         "@mdx-js/react": "^3.1.0",
         "@next/mdx": "^15.4.5",
@@ -596,6 +597,167 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@libsql/client": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.0.tgz",
+      "integrity": "sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/core": "^0.17.0",
+        "@libsql/hrana-client": "^0.9.0",
+        "js-base64": "^3.7.5",
+        "libsql": "^0.5.22",
+        "promise-limit": "^2.7.0"
+      }
+    },
+    "node_modules/@libsql/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@libsql/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-hnZRnJHiS+nrhHKLGYPoJbc78FE903MSDrFJTbftxo+e52X+E0Y0fHOCVYsKWcg6XgB7BbJYUrz/xEkVTSaipw==",
+      "license": "MIT",
+      "dependencies": {
+        "js-base64": "^3.7.5"
+      }
+    },
+    "node_modules/@libsql/darwin-arm64": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-arm64/-/darwin-arm64-0.5.22.tgz",
+      "integrity": "sha512-4B8ZlX3nIDPndfct7GNe0nI3Yw6ibocEicWdC4fvQbSs/jdq/RC2oCsoJxJ4NzXkvktX70C1J4FcmmoBy069UA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/darwin-x64": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/darwin-x64/-/darwin-x64-0.5.22.tgz",
+      "integrity": "sha512-ny2HYWt6lFSIdNFzUFIJ04uiW6finXfMNJ7wypkAD8Pqdm6nAByO+Fdqu8t7sD0sqJGeUCiOg480icjyQ2/8VA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@libsql/hrana-client": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@libsql/hrana-client/-/hrana-client-0.9.0.tgz",
+      "integrity": "sha512-pxQ1986AuWfPX4oXzBvLwBnfgKDE5OMhAdR/5cZmRaB4Ygz5MecQybvwZupnRz341r2CtFmbk/BhSu7k2Lm+Jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@libsql/isomorphic-ws": "^0.1.5",
+        "cross-fetch": "^4.0.0",
+        "js-base64": "^3.7.5",
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/@libsql/isomorphic-ws": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@libsql/isomorphic-ws/-/isomorphic-ws-0.1.5.tgz",
+      "integrity": "sha512-DtLWIH29onUYR00i0GlQ3UdcTRC6EP4u9w/h9LxpUZJWRMARk6dQwZ6Jkd+QdwVpuAOrdxt18v0K2uIYR3fwFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ws": "^8.5.4",
+        "ws": "^8.13.0"
+      }
+    },
+    "node_modules/@libsql/linux-arm-gnueabihf": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-gnueabihf/-/linux-arm-gnueabihf-0.5.22.tgz",
+      "integrity": "sha512-3Uo3SoDPJe/zBnyZKosziRGtszXaEtv57raWrZIahtQDsjxBVjuzYQinCm9LRCJCUT5t2r5Z5nLDPJi2CwZVoA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm-musleabihf": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm-musleabihf/-/linux-arm-musleabihf-0.5.22.tgz",
+      "integrity": "sha512-LCsXh07jvSojTNJptT9CowOzwITznD+YFGGW+1XxUr7fS+7/ydUrpDfsMX7UqTqjm7xG17eq86VkWJgHJfvpNg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-gnu": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-gnu/-/linux-arm64-gnu-0.5.22.tgz",
+      "integrity": "sha512-KSdnOMy88c9mpOFKUEzPskSaF3VLflfSUCBwas/pn1/sV3pEhtMF6H8VUCd2rsedwoukeeCSEONqX7LLnQwRMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-arm64-musl": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-arm64-musl/-/linux-arm64-musl-0.5.22.tgz",
+      "integrity": "sha512-mCHSMAsDTLK5YH//lcV3eFEgiR23Ym0U9oEvgZA0667gqRZg/2px+7LshDvErEKv2XZ8ixzw3p1IrBzLQHGSsw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-gnu": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-gnu/-/linux-x64-gnu-0.5.22.tgz",
+      "integrity": "sha512-kNBHaIkSg78Y4BqAdgjcR2mBilZXs4HYkAmi58J+4GRwDQZh5fIUWbnQvB9f95DkWUIGVeenqLRFY2pcTmlsew==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/linux-x64-musl": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/linux-x64-musl/-/linux-x64-musl-0.5.22.tgz",
+      "integrity": "sha512-UZ4Xdxm4pu3pQXjvfJiyCzZop/9j/eA2JjmhMaAhe3EVLH2g11Fy4fwyUp9sT1QJYR1kpc2JLuybPM0kuXv/Tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@libsql/win32-x64-msvc": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/@libsql/win32-x64-msvc/-/win32-x64-msvc-0.5.22.tgz",
+      "integrity": "sha512-Fj0j8RnBpo43tVZUVoNK6BV/9AtDUM5S7DF3LB4qTYg1LMSZqi3yeCneUTLJD6XomQJlZzbI4mst89yspVSAnA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@mdx-js/loader": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.0.tgz",
@@ -670,6 +832,12 @@
         "@types/react": ">=16",
         "react": ">=16"
       }
+    },
+    "node_modules/@neon-rs/load": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@neon-rs/load/-/load-0.0.4.tgz",
+      "integrity": "sha512-kTPhdZyTQxB+2wpiRcFWrDcejc4JI6tkPuS7UZCG4l6Zvc5kU/gGQ/ozvHTh1XR5tS+UlfAfGuPajjzQjCiHCw==",
+      "license": "MIT"
     },
     "node_modules/@next/env": {
       "version": "15.2.4",
@@ -2327,7 +2495,6 @@
       "version": "22.16.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.5.tgz",
       "integrity": "sha512-bJFoMATwIGaxxx8VJPeM8TonI8t579oRvgAuT8zFugJsJZgzqv0Fu8Mhp68iecjzG7cnN3mO2dJQ5uUM2EFrgQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2358,6 +2525,15 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.0",
@@ -2839,6 +3015,35 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2992,6 +3197,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/date-fns": {
@@ -3380,6 +3594,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3408,6 +3645,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -3827,6 +4076,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-base64": {
+      "version": "3.7.8",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
+      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3853,6 +4108,47 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/libsql": {
+      "version": "0.5.22",
+      "resolved": "https://registry.npmjs.org/libsql/-/libsql-0.5.22.tgz",
+      "integrity": "sha512-NscWthMQt7fpU8lqd7LXMvT9pi+KhhmTHAJWUB/Lj6MWa0MKFv0F2V4C6WKKpjCVZl0VwcDz4nOI3CyaT1DDiA==",
+      "cpu": [
+        "x64",
+        "arm64",
+        "wasm32",
+        "arm"
+      ],
+      "license": "MIT",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@neon-rs/load": "^0.0.4",
+        "detect-libc": "2.0.2"
+      },
+      "optionalDependencies": {
+        "@libsql/darwin-arm64": "0.5.22",
+        "@libsql/darwin-x64": "0.5.22",
+        "@libsql/linux-arm-gnueabihf": "0.5.22",
+        "@libsql/linux-arm-musleabihf": "0.5.22",
+        "@libsql/linux-arm64-gnu": "0.5.22",
+        "@libsql/linux-arm64-musl": "0.5.22",
+        "@libsql/linux-x64-gnu": "0.5.22",
+        "@libsql/linux-x64-musl": "0.5.22",
+        "@libsql/win32-x64-msvc": "0.5.22"
+      }
+    },
+    "node_modules/libsql/node_modules/detect-libc": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.2.tgz",
+      "integrity": "sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/lilconfig": {
@@ -5159,6 +5455,44 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -5456,6 +5790,12 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "license": "MIT"
+    },
+    "node_modules/promise-limit": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
+      "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
+      "license": "ISC"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -6457,6 +6797,12 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/trim-lines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
@@ -6508,7 +6854,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -6839,6 +7184,31 @@
         "d3-timer": "^3.0.1"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6951,6 +7321,27 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.1",
+    "@libsql/client": "^0.17.0",
     "@mdx-js/loader": "^3.1.0",
     "@mdx-js/react": "^3.1.0",
     "@next/mdx": "^15.4.5",


### PR DESCRIPTION
## Summary\n- add Turso-backed blog admin v1 under /admin (login, list, create, edit, publish/unpublish)\n- implement magic link auth flow with email whitelist and Turso token/session tables\n- refactor blog data layer to hybrid mode (Turso + filesystem MDX, Turso wins on slug conflicts)\n- keep public SEO pipeline for Turso posts (metadata/canonical/OG/JSON-LD)\n- document setup/env vars for deploy and admin usage\n\n## Notes\n- V1 uses textarea Markdown/MDX (no rich editor, no image upload)\n- Turso migrations run lazily on first admin action\n- Added one tax-focused article (compliance tributario)\n\n## Validation\n- npm run build