### PR TITLE
Refine SEO copy and internal linking

### DIFF
--- a/app/areas/consultoria-juridica/page.tsx
+++ b/app/areas/consultoria-juridica/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { Briefcase, FileText, Shield, Users } from "lucide-react"
 import AreaPage from "@/components/area-page"
-import { createAreaMetadata } from "@/lib/seo"
+import JsonLd from "@/components/seo/json-ld"
+import { buildAreaServiceSchema, buildFaqSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("consultoria-juridica")
 
@@ -52,6 +53,45 @@ export default function ConsultoriaJuridicaPage() {
       finalText="Uma boa consulta preventiva reduz retrabalho, exposição e custo de correção. Se a decisão envolver tributos, a análise segue integrada com a frente principal do escritório."
       finalPrimaryCta={{ label: "Agendar consulta", href: "/#contact" }}
       finalSecondaryCta={{ label: "Falar com tributário", href: "/areas/direito-tributario" }}
-    />
+      relatedLinks={[
+        { label: "Direito tributário para empresas e profissionais", href: "/areas/direito-tributario" },
+        { label: "Consultoria fiscal para empresas: quando contratar antes da autuação", href: "/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita" },
+        { label: "Direito empresarial em São Bernardo do Campo", href: "/areas/direito-empresarial" },
+      ]}
+      faqs={[
+        {
+          question: "Quando vale contratar consultoria jurídica preventiva?",
+          answer: "Antes de assinar contratos, reorganizar a empresa, revisar processos internos ou assumir risco relevante sem clareza jurídica suficiente.",
+        },
+        {
+          question: "Consultoria jurídica substitui a análise tributária?",
+          answer: "Não. Quando a decisão tem reflexo fiscal, a consultoria jurídica precisa caminhar junto com a análise tributária para evitar visão incompleta.",
+        },
+      ]}
+    >
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "consultoria-juridica",
+          serviceType: "Consultoria Jurídica",
+          name: "Consultoria Jurídica Preventiva em São Bernardo do Campo",
+          description:
+            "Consultoria jurídica preventiva para empresas e profissionais, com pareceres, due diligence e suporte estratégico.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando vale contratar consultoria jurídica preventiva?",
+            answer:
+              "Antes de assinar contratos, reorganizar a empresa, revisar processos internos ou assumir risco relevante sem clareza jurídica suficiente.",
+          },
+          {
+            question: "Consultoria jurídica substitui a análise tributária?",
+            answer:
+              "Não. Quando a decisão tem reflexo fiscal, a consultoria jurídica precisa caminhar junto com a análise tributária para evitar visão incompleta.",
+          },
+        ])}
+      />
+    </AreaPage>
   )
 }

--- a/app/areas/direito-civil/page.tsx
+++ b/app/areas/direito-civil/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { FileText, Scale, Shield, Users } from "lucide-react"
 import AreaPage from "@/components/area-page"
-import { createAreaMetadata } from "@/lib/seo"
+import JsonLd from "@/components/seo/json-ld"
+import { buildAreaServiceSchema, buildFaqSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("direito-civil")
 
@@ -52,6 +53,45 @@ export default function DireitoCivilPage() {
       finalText="A análise certa no início reduz desgaste, custo e exposição. Se houver impacto patrimonial ou empresarial, a frente tributária entra junto na leitura do caso."
       finalPrimaryCta={{ label: "Agendar consulta", href: "/#contact" }}
       finalSecondaryCta={{ label: "Falar com tributário", href: "/areas/direito-tributario" }}
-    />
+      relatedLinks={[
+        { label: "Direito empresarial em São Bernardo do Campo", href: "/areas/direito-empresarial" },
+        { label: "Direito tributário para empresas e profissionais", href: "/areas/direito-tributario" },
+        { label: "Blog de Direito Tributário para Empresas", href: "/blog" },
+      ]}
+      faqs={[
+        {
+          question: "Quando buscar apoio em direito civil?",
+          answer: "Quando há necessidade de revisar contratos, lidar com responsabilidade civil, proteger patrimônio ou organizar um conflito antes que ele escale.",
+        },
+        {
+          question: "Direito civil pode se conectar com tributário?",
+          answer: "Sim. Em contratos, disputas patrimoniais e relações entre sócios, o reflexo fiscal pode ser relevante e precisa entrar cedo na análise.",
+        },
+      ]}
+    >
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "direito-civil",
+          serviceType: "Direito Civil",
+          name: "Atuação em Direito Civil em São Bernardo do Campo",
+          description:
+            "Atuação em Direito Civil com suporte em contratos, responsabilidade civil e proteção patrimonial.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando buscar apoio em direito civil?",
+            answer:
+              "Quando há necessidade de revisar contratos, lidar com responsabilidade civil, proteger patrimônio ou organizar um conflito antes que ele escale.",
+          },
+          {
+            question: "Direito civil pode se conectar com tributário?",
+            answer:
+              "Sim. Em contratos, disputas patrimoniais e relações entre sócios, o reflexo fiscal pode ser relevante e precisa entrar cedo na análise.",
+          },
+        ])}
+      />
+    </AreaPage>
   )
 }

--- a/app/areas/direito-empresarial/page.tsx
+++ b/app/areas/direito-empresarial/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { Building, FileText, Shield, Users } from "lucide-react"
 import AreaPage from "@/components/area-page"
-import { createAreaMetadata } from "@/lib/seo"
+import JsonLd from "@/components/seo/json-ld"
+import { buildAreaServiceSchema, buildFaqSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("direito-empresarial")
 
@@ -52,6 +53,45 @@ export default function DireitoEmpresarialPage() {
       finalText="Revisamos contratos, estrutura e risco da operação. Quando houver reflexo fiscal, o encaminhamento para o tributário já entra no mesmo fluxo."
       finalPrimaryCta={{ label: "Agendar consulta", href: "/#contact" }}
       finalSecondaryCta={{ label: "Ir para Direito Tributário", href: "/areas/direito-tributario" }}
-    />
+      relatedLinks={[
+        { label: "Direito tributário para empresas e profissionais", href: "/areas/direito-tributario" },
+        { label: "Consultoria jurídica preventiva em São Bernardo do Campo", href: "/areas/consultoria-juridica" },
+        { label: "Planejamento tributário para empresas: quando revisar e como reduzir riscos", href: "/blog/planejamento-tributario-para-empresas-como-reduzir-riscos" },
+      ]}
+      faqs={[
+        {
+          question: "Quando procurar apoio em direito empresarial?",
+          answer: "Quando a empresa precisa revisar contratos, estrutura societária, compliance ou tomar decisão que pode afetar risco operacional e financeiro.",
+        },
+        {
+          question: "Direito empresarial também pode ter impacto tributário?",
+          answer: "Sim. Mudanças societárias, contratos e reorganizações podem alterar exposição fiscal e precisam de leitura conjunta com o tributário.",
+        },
+      ]}
+    >
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "direito-empresarial",
+          serviceType: "Direito Empresarial",
+          name: "Consultoria em Direito Empresarial em São Bernardo do Campo",
+          description:
+            "Consultoria em Direito Empresarial para empresas, com apoio em contratos comerciais, compliance, estrutura societária e decisões com reflexo tributário.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando procurar apoio em direito empresarial?",
+            answer:
+              "Quando a empresa precisa revisar contratos, estrutura societária, compliance ou tomar decisão que pode afetar risco operacional e financeiro.",
+          },
+          {
+            question: "Direito empresarial também pode ter impacto tributário?",
+            answer:
+              "Sim. Mudanças societárias, contratos e reorganizações podem alterar exposição fiscal e precisam de leitura conjunta com o tributário.",
+          },
+        ])}
+      />
+    </AreaPage>
   )
 }

--- a/app/areas/direito-imobiliario/page.tsx
+++ b/app/areas/direito-imobiliario/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { FileText, Home, Scale, Shield } from "lucide-react"
 import AreaPage from "@/components/area-page"
-import { createAreaMetadata } from "@/lib/seo"
+import JsonLd from "@/components/seo/json-ld"
+import { buildAreaServiceSchema, buildFaqSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("direito-imobiliario")
 
@@ -52,6 +53,45 @@ export default function DireitoImobiliarioPage() {
       finalText="Revisar a operação antes da assinatura reduz risco contratual e custo de correção. Se houver efeito fiscal, a análise segue integrada com a frente tributária."
       finalPrimaryCta={{ label: "Agendar consulta", href: "/#contact" }}
       finalSecondaryCta={{ label: "Falar com tributário", href: "/areas/direito-tributario" }}
-    />
+      relatedLinks={[
+        { label: "Direito tributário para empresas e profissionais", href: "/areas/direito-tributario" },
+        { label: "Recuperação de créditos tributários para empresas: quem pode avaliar", href: "/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados" },
+        { label: "Direito civil e contratos em São Bernardo do Campo", href: "/areas/direito-civil" },
+      ]}
+      faqs={[
+        {
+          question: "Quando procurar apoio em direito imobiliário?",
+          answer: "Antes de comprar, vender, alugar ou regularizar imóvel, especialmente quando há documentação complexa, patrimônio relevante ou dúvida sobre segurança da operação.",
+        },
+        {
+          question: "Operação imobiliária pode ter impacto tributário?",
+          answer: "Sim. ITBI, ganho de capital, holdings e organização patrimonial podem alterar o custo e o risco da operação imobiliária.",
+        },
+      ]}
+    >
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "direito-imobiliario",
+          serviceType: "Direito Imobiliário",
+          name: "Assessoria em Direito Imobiliário em São Bernardo do Campo",
+          description:
+            "Assessoria em Direito Imobiliário para compra e venda, locações e regularização de imóveis, com atenção a risco patrimonial e impacto tributário.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando procurar apoio em direito imobiliário?",
+            answer:
+              "Antes de comprar, vender, alugar ou regularizar imóvel, especialmente quando há documentação complexa, patrimônio relevante ou dúvida sobre segurança da operação.",
+          },
+          {
+            question: "Operação imobiliária pode ter impacto tributário?",
+            answer:
+              "Sim. ITBI, ganho de capital, holdings e organização patrimonial podem alterar o custo e o risco da operação imobiliária.",
+          },
+        ])}
+      />
+    </AreaPage>
   )
 }

--- a/app/areas/direito-processual/page.tsx
+++ b/app/areas/direito-processual/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { FileText, Gavel, Scale, Shield } from "lucide-react"
 import AreaPage from "@/components/area-page"
-import { createAreaMetadata } from "@/lib/seo"
+import JsonLd from "@/components/seo/json-ld"
+import { buildAreaServiceSchema, buildFaqSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("direito-processual")
 
@@ -52,6 +53,45 @@ export default function DireitoProcessualPage() {
       finalText="A resposta errada aumenta custo, demora e exposição. Em demandas com componente fiscal, a condução considera desde o início o impacto tributário do caso."
       finalPrimaryCta={{ label: "Agendar consulta", href: "/#contact" }}
       finalSecondaryCta={{ label: "Ir para Direito Tributário", href: "/areas/direito-tributario" }}
-    />
+      relatedLinks={[
+        { label: "Execução fiscal para empresas: o que fazer nos primeiros dias", href: "/blog/defesa-em-execucao-fiscal-estrategias-para-empresas" },
+        { label: "Como suspender execução fiscal da empresa: medidas possíveis e o que avaliar", href: "/blog/como-suspender-execucao-fiscal-para-empresa" },
+        { label: "Direito tributário para empresas e profissionais", href: "/areas/direito-tributario" },
+      ]}
+      faqs={[
+        {
+          question: "Quando procurar apoio em direito processual?",
+          answer: "Quando já existe disputa judicial ou administrativa, ou quando a resposta processual precisa ser definida com rapidez para evitar perda de prazo e aumento de exposição.",
+        },
+        {
+          question: "Processo com cobrança fiscal exige análise tributária junto?",
+          answer: "Sim. Quando o litígio envolve cobrança tributária, execução fiscal ou tese fiscal, a estratégia processual precisa caminhar junto com o tributário.",
+        },
+      ]}
+    >
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "direito-processual",
+          serviceType: "Direito Processual",
+          name: "Estratégia Processual em São Bernardo do Campo",
+          description:
+            "Representação em processos judiciais e administrativos, com foco em estratégia processual, recursos, execuções e disputas com impacto tributário.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando procurar apoio em direito processual?",
+            answer:
+              "Quando já existe disputa judicial ou administrativa, ou quando a resposta processual precisa ser definida com rapidez para evitar perda de prazo e aumento de exposição.",
+          },
+          {
+            question: "Processo com cobrança fiscal exige análise tributária junto?",
+            answer:
+              "Sim. Quando o litígio envolve cobrança tributária, execução fiscal ou tese fiscal, a estratégia processual precisa caminhar junto com o tributário.",
+          },
+        ])}
+      />
+    </AreaPage>
   )
 }

--- a/app/areas/direito-trabalhista/page.tsx
+++ b/app/areas/direito-trabalhista/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next"
 import { FileText, Scale, Shield, Users } from "lucide-react"
 import AreaPage from "@/components/area-page"
-import { createAreaMetadata } from "@/lib/seo"
+import JsonLd from "@/components/seo/json-ld"
+import { buildAreaServiceSchema, buildFaqSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("direito-trabalhista")
 
@@ -52,6 +53,45 @@ export default function DireitoTrabalhistaPage() {
       finalText="Revisar rotina, contratos e contingências antes do litígio costuma custar menos do que corrigir depois. Quando o caso tocar estrutura fiscal, a frente tributária entra no mesmo fluxo."
       finalPrimaryCta={{ label: "Agendar consulta", href: "/#contact" }}
       finalSecondaryCta={{ label: "Falar com tributário", href: "/areas/direito-tributario" }}
-    />
+      relatedLinks={[
+        { label: "Consultoria jurídica preventiva em São Bernardo do Campo", href: "/areas/consultoria-juridica" },
+        { label: "Direito tributário para empresas e profissionais", href: "/areas/direito-tributario" },
+        { label: "Consultoria fiscal para empresas: quando contratar antes da autuação", href: "/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita" },
+      ]}
+      faqs={[
+        {
+          question: "Quando vale buscar consultoria trabalhista preventiva?",
+          answer: "Antes de acumular passivo, revisar contratos, ajustar rotinas internas ou responder a sinais de risco trabalhista recorrente.",
+        },
+        {
+          question: "Passivo trabalhista pode afetar o planejamento fiscal?",
+          answer: "Sim. O impacto financeiro e estrutural do passivo trabalhista pode alterar decisões de caixa, encargos e leitura mais ampla da operação.",
+        },
+      ]}
+    >
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "direito-trabalhista",
+          serviceType: "Direito Trabalhista",
+          name: "Assessoria em Direito Trabalhista em São Bernardo do Campo",
+          description:
+            "Atendimento em Direito Trabalhista para rescisões, ações trabalhistas e consultoria preventiva, com foco em redução de passivo e organização da operação.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando vale buscar consultoria trabalhista preventiva?",
+            answer:
+              "Antes de acumular passivo, revisar contratos, ajustar rotinas internas ou responder a sinais de risco trabalhista recorrente.",
+          },
+          {
+            question: "Passivo trabalhista pode afetar o planejamento fiscal?",
+            answer:
+              "Sim. O impacto financeiro e estrutural do passivo trabalhista pode alterar decisões de caixa, encargos e leitura mais ampla da operação.",
+          },
+        ])}
+      />
+    </AreaPage>
   )
 }

--- a/app/areas/direito-tributario/page.tsx
+++ b/app/areas/direito-tributario/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next"
 import { Calculator, FileText, Scale, Shield } from "lucide-react"
 import AreaPage from "@/components/area-page"
 import JsonLd from "@/components/seo/json-ld"
-import { buildTaxServiceSchema, createAreaMetadata } from "@/lib/seo"
+import { buildAreaServiceSchema, buildFaqSchema, buildTaxServiceSchema, createAreaMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createAreaMetadata("direito-tributario")
 
@@ -53,8 +53,55 @@ export default function DireitoTributarioPage() {
       finalText="A análise certa reduz improviso, protege patrimônio e organiza os próximos passos com base no risco real da empresa."
       finalPrimaryCta={{ label: "Solicitar atendimento", href: "/#contact" }}
       finalSecondaryCta={{ label: "Voltar ao início", href: "/" }}
+      relatedLinks={[
+        { label: "Planejamento tributário para empresas: quando revisar e como reduzir riscos", href: "/blog/planejamento-tributario-para-empresas-como-reduzir-riscos" },
+        { label: "Execução fiscal para empresas: o que fazer nos primeiros dias", href: "/blog/defesa-em-execucao-fiscal-estrategias-para-empresas" },
+        { label: "Consultoria fiscal para empresas: quando contratar antes da autuação", href: "/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita" },
+      ]}
+      faqs={[
+        {
+          question: "Quando vale procurar uma advogada tributarista?",
+          answer: "Quando a empresa enfrenta cobrança tributária, dúvida sobre regime, execução fiscal, autuação ou necessidade de revisar a estrutura tributária com mais segurança.",
+        },
+        {
+          question: "Planejamento tributário serve apenas para empresas grandes?",
+          answer: "Não. Empresas de diferentes portes podem revisar regime, operação e obrigações para reduzir risco e evitar pagamento indevido dentro da legalidade.",
+        },
+        {
+          question: "Execução fiscal sempre exige processo longo?",
+          answer: "Não necessariamente. A estratégia depende da fase da cobrança, dos documentos, da existência de garantia e das alternativas administrativas ou judiciais disponíveis.",
+        },
+      ]}
     >
       <JsonLd data={buildTaxServiceSchema()} />
+      <JsonLd
+        data={buildAreaServiceSchema({
+          slug: "direito-tributario",
+          serviceType: "Direito Tributário",
+          name: "Advogada Tributarista em São Bernardo do Campo",
+          description:
+            "Assessoria em Direito Tributário para empresas e profissionais, com foco em planejamento tributário, consultoria fiscal, execução fiscal e contencioso tributário.",
+        })}
+      />
+      <JsonLd
+        data={buildFaqSchema([
+          {
+            question: "Quando vale procurar uma advogada tributarista?",
+            answer:
+              "Quando a empresa enfrenta cobrança tributária, dúvida sobre regime, execução fiscal, autuação ou necessidade de revisar a estrutura tributária com mais segurança.",
+          },
+          {
+            question: "Planejamento tributário serve apenas para empresas grandes?",
+            answer:
+              "Não. Empresas de diferentes portes podem revisar regime, operação e obrigações para reduzir risco e evitar pagamento indevido dentro da legalidade.",
+          },
+          {
+            question: "Execução fiscal sempre exige processo longo?",
+            answer:
+              "Não necessariamente. A estratégia depende da fase da cobrança, dos documentos, da existência de garantia e das alternativas administrativas ou judiciais disponíveis.",
+          },
+        ])}
+      />
     </AreaPage>
   )
 }

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -7,9 +7,9 @@ import { blogSans, blogSerif, formatBlogDate } from "@/lib/blog-design"
 import { createPageMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createPageMetadata({
-  title: "Blog Jurídico e Tributário",
+  title: "Blog de Direito Tributário para Empresas",
   description:
-    "Conteúdo jurídico com foco em Direito Tributário, compliance, contratos e prevenção de riscos para empresas e profissionais.",
+    "Blog de Direito Tributário com conteúdos sobre planejamento tributário, execução fiscal, consultoria fiscal, compliance e prevenção de riscos para empresas.",
   path: "/blog",
   keywords: [
     "blog direito tributário",
@@ -17,6 +17,7 @@ export const metadata: Metadata = createPageMetadata({
     "compliance tributário",
     "execução fiscal",
     "planejamento tributário",
+    "consultoria fiscal",
   ],
 })
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,8 @@ export const metadata: Metadata = {
   keywords: [
     "advogada tributarista",
     "direito tributário",
+    "advogada tributarista são bernardo do campo",
+    "advogado tributário são bernardo do campo",
     "planejamento tributário",
     "execução fiscal",
     "consultoria fiscal",

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import "./globals.css"
+import FloatingWhatsApp from "@/components/floating-whatsapp"
 import { blogSans } from "@/lib/blog-design"
 import { SEO } from "@/lib/seo"
 
@@ -52,6 +53,7 @@ export default function RootLayout({
     <html lang="pt-BR" suppressHydrationWarning>
       <body suppressHydrationWarning className={`${blogSans.className} antialiased`}>
         {children}
+        <FloatingWhatsApp />
       </body>
     </html>
   )

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,15 +11,17 @@ import JsonLd from "@/components/seo/json-ld"
 import { buildLegalServiceSchema, createPageMetadata } from "@/lib/seo"
 
 export const metadata: Metadata = createPageMetadata({
-  title: "Advogada Tributarista em São Bernardo do Campo",
+  title: "Advogada Tributarista em São Bernardo do Campo para Empresas",
   description:
-    "Assessoria em Direito Tributário para empresas e profissionais em São Bernardo do Campo. Planejamento tributário, execuções fiscais, consultoria fiscal e contencioso tributário.",
+    "Advogada tributarista em São Bernardo do Campo para empresas e profissionais. Assessoria em planejamento tributário, execução fiscal, consultoria fiscal e prevenção de riscos tributários.",
   path: "/",
   keywords: [
     "advogada tributarista são bernardo do campo",
     "direito tributário são bernardo do campo",
+    "advogado tributário são bernardo do campo",
     "planejamento tributário",
     "execução fiscal",
+    "consultoria fiscal",
   ],
 })
 

--- a/components/area-page.tsx
+++ b/components/area-page.tsx
@@ -22,6 +22,16 @@ type AreaCta = {
   href: string
 }
 
+type AreaFaq = {
+  question: string
+  answer: string
+}
+
+type AreaRelatedLink = {
+  label: string
+  href: string
+}
+
 interface AreaPageProps {
   icon: LucideIcon
   title: string
@@ -38,6 +48,8 @@ interface AreaPageProps {
   finalText: string
   finalPrimaryCta: AreaCta
   finalSecondaryCta: AreaCta
+  faqs?: AreaFaq[]
+  relatedLinks?: AreaRelatedLink[]
   children?: ReactNode
 }
 
@@ -57,6 +69,8 @@ export default function AreaPage({
   finalText,
   finalPrimaryCta,
   finalSecondaryCta,
+  faqs,
+  relatedLinks,
   children,
 }: AreaPageProps) {
   return (
@@ -179,6 +193,55 @@ export default function AreaPage({
             </div>
           </div>
         </section>
+
+        {faqs && faqs.length > 0 ? (
+          <section className="py-12">
+            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="mx-auto max-w-6xl">
+                <div className="home-panel rounded-[2rem] p-7 sm:p-10">
+                  <h2 className={`${blogSerif.className} text-4xl leading-tight text-custom-text-secondary sm:text-5xl`}>
+                    Perguntas frequentes sobre {title.toLowerCase()}
+                  </h2>
+                  <div className="mt-8 grid gap-5 md:grid-cols-2">
+                    {faqs.map((item) => (
+                      <article key={item.question} className="rounded-[1.6rem] border border-custom-text-primary/12 bg-black/10 p-6">
+                        <h3 className={`${blogSerif.className} text-2xl leading-tight text-custom-text-secondary`}>
+                          {item.question}
+                        </h3>
+                        <p className="mt-3 text-sm leading-7 text-custom-text-primary/78">{item.answer}</p>
+                      </article>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        ) : null}
+
+        {relatedLinks && relatedLinks.length > 0 ? (
+          <section className="py-12">
+            <div className="container mx-auto px-4 sm:px-6 lg:px-8">
+              <div className="mx-auto max-w-6xl">
+                <div className="rounded-[1.8rem] border border-custom-text-primary/12 bg-white/5 p-7">
+                  <h2 className={`${blogSerif.className} text-3xl leading-tight text-custom-text-secondary sm:text-4xl`}>
+                    Leitura relacionada
+                  </h2>
+                  <div className="mt-6 grid gap-4 md:grid-cols-3">
+                    {relatedLinks.map((item) => (
+                      <Link
+                        key={item.href}
+                        href={item.href}
+                        className="rounded-[1.4rem] border border-custom-text-primary/10 bg-black/10 p-5 text-sm leading-7 text-custom-text-primary/78 transition hover:border-custom-text-primary/26 hover:text-custom-text-secondary"
+                      >
+                        {item.label}
+                      </Link>
+                    ))}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+        ) : null}
 
         <section className="py-12 pb-24">
           <div className="container mx-auto px-4 sm:px-6 lg:px-8">

--- a/components/blog.tsx
+++ b/components/blog.tsx
@@ -21,11 +21,11 @@ export default async function Blog() {
                 Conteúdo estratégico
               </div>
               <h2 className={`${blogSerif.className} max-w-3xl text-5xl leading-[0.96] text-custom-text-secondary sm:text-6xl`}>
-                O blog agora funciona como extensão editorial da proposta do escritório.
+                Conteúdo de Direito Tributário para empresas que precisam entender risco antes de decidir.
               </h2>
               <p className="max-w-2xl text-lg leading-8 text-custom-text-primary/84">
-                Em vez de artigos soltos, a home apresenta o blog como repertório de decisão: execução fiscal,
-                planejamento tributário, cobrança e prevenção com curadoria clara.
+                O blog organiza conteúdos sobre planejamento tributário, execução fiscal, cobrança tributária,
+                consultoria fiscal e prevenção de riscos com recorte prático para tomada de decisão.
               </p>
               <Link href="/blog" className="inline-flex">
                 <Button className="rounded-full bg-custom-text-primary px-7 text-custom-bg-primary hover:bg-custom-text-secondary">

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -67,24 +67,26 @@ export default function Contact() {
     "h-12 rounded-2xl border-custom-text-primary/18 bg-custom-bg-primary/45 text-custom-text-secondary placeholder:text-custom-text-primary/48 focus-visible:ring-custom-text-primary/25"
 
   return (
-    <section id="contact" className="relative py-24">
+    <section id="contact" className="relative py-18 sm:py-24">
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-7xl">
-          <div className="home-paper rounded-[2.2rem] p-7 text-slate-900 shadow-[0_32px_120px_rgba(0,0,0,0.22)] sm:p-10">
+          <div className="home-paper rounded-[2rem] p-5 text-slate-900 shadow-[0_32px_120px_rgba(0,0,0,0.22)] sm:rounded-[2.2rem] sm:p-10">
             <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
-              <div className="space-y-8">
+              <div className="space-y-6 sm:space-y-8">
                 <div className="section-kicker text-[#7f5b39]">
                   <Sparkles className="h-3.5 w-3.5" />
                   Contato direto
                 </div>
 
                 <div>
-                  <h2 className={`${blogSerif.className} max-w-3xl text-5xl leading-[0.96] text-slate-950 sm:text-6xl`}>
-                    Agende uma consulta tributária ou empresarial com mais contexto e menos ruído.
+                  <h2
+                    className={`${blogSerif.className} max-w-3xl text-[2.9rem] leading-[0.98] tracking-[-0.03em] text-slate-950 sm:text-5xl lg:text-6xl`}
+                  >
+                    Fale sobre seu caso com clareza.
                   </h2>
-                  <p className="mt-5 max-w-2xl text-base leading-8 text-slate-700">
-                    Use o formulário para descrever a situação com objetividade. Se houver cobrança, autuação,
-                    execução fiscal ou decisão empresarial com reflexo tributário, isso deve aparecer logo no primeiro contato.
+                  <p className="mt-4 max-w-2xl text-[0.98rem] leading-7 text-slate-700 sm:mt-5 sm:text-base sm:leading-8">
+                    Se houver cobrança, execução fiscal, autuação ou uma decisão empresarial com impacto tributário,
+                    descreva isso logo no primeiro contato.
                   </p>
                 </div>
 
@@ -111,7 +113,7 @@ export default function Contact() {
                       body: "Segunda a Sexta: 8h às 18h\nSábado: 8h às 12h",
                     },
                   ].map((item) => (
-                    <div key={item.title} className="rounded-[1.5rem] border border-[#dcc3a4] bg-white/65 p-5">
+                    <div key={item.title} className="rounded-[1.35rem] border border-[#dcc3a4] bg-white/65 p-4 sm:rounded-[1.5rem] sm:p-5">
                       <div className="flex items-start gap-4">
                         <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-[#ecd5ba] text-[#7f5b39]">
                           <item.icon className="h-5 w-5" />
@@ -126,12 +128,12 @@ export default function Contact() {
                 </div>
               </div>
 
-              <div className="rounded-[2rem] bg-[#161c25] p-6 text-custom-text-secondary shadow-[0_24px_80px_rgba(0,0,0,0.28)] sm:p-8">
+              <div className="rounded-[1.8rem] bg-[#161c25] p-5 text-custom-text-secondary shadow-[0_24px_80px_rgba(0,0,0,0.28)] sm:rounded-[2rem] sm:p-8">
                 <div className="mb-6 border-b border-custom-text-primary/10 pb-6">
                   <p className="text-xs uppercase tracking-[0.24em] text-custom-text-primary/62">Formulário de triagem</p>
-                  <h3 className={`${blogSerif.className} mt-3 text-4xl`}>Solicitar atendimento jurídico</h3>
+                  <h3 className={`${blogSerif.className} mt-3 text-3xl sm:text-4xl`}>Solicitar atendimento</h3>
                   <p className="mt-3 text-sm leading-7 text-custom-text-primary/76">
-                    Informe o máximo possível em poucas linhas: natureza da demanda, urgência e contexto empresarial.
+                    Resuma a demanda, a urgência e o ponto principal que precisa ser analisado.
                   </p>
                 </div>
 

--- a/components/contact.tsx
+++ b/components/contact.tsx
@@ -80,11 +80,11 @@ export default function Contact() {
 
                 <div>
                   <h2 className={`${blogSerif.className} max-w-3xl text-5xl leading-[0.96] text-slate-950 sm:text-6xl`}>
-                    Traga o caso com contexto. A resposta começa melhor quando a triagem já vem certa.
+                    Agende uma consulta tributária ou empresarial com mais contexto e menos ruído.
                   </h2>
                   <p className="mt-5 max-w-2xl text-base leading-8 text-slate-700">
-                    Use o formulário para descrever a situação com objetividade. Se houver cobrança, autuação, execução
-                    ou decisão empresarial com reflexo fiscal, isso deve aparecer logo no primeiro contato.
+                    Use o formulário para descrever a situação com objetividade. Se houver cobrança, autuação,
+                    execução fiscal ou decisão empresarial com reflexo tributário, isso deve aparecer logo no primeiro contato.
                   </p>
                 </div>
 
@@ -129,7 +129,7 @@ export default function Contact() {
               <div className="rounded-[2rem] bg-[#161c25] p-6 text-custom-text-secondary shadow-[0_24px_80px_rgba(0,0,0,0.28)] sm:p-8">
                 <div className="mb-6 border-b border-custom-text-primary/10 pb-6">
                   <p className="text-xs uppercase tracking-[0.24em] text-custom-text-primary/62">Formulário de triagem</p>
-                  <h3 className={`${blogSerif.className} mt-3 text-4xl`}>Agende sua consulta</h3>
+                  <h3 className={`${blogSerif.className} mt-3 text-4xl`}>Solicitar atendimento jurídico</h3>
                   <p className="mt-3 text-sm leading-7 text-custom-text-primary/76">
                     Informe o máximo possível em poucas linhas: natureza da demanda, urgência e contexto empresarial.
                   </p>

--- a/components/floating-whatsapp.tsx
+++ b/components/floating-whatsapp.tsx
@@ -1,0 +1,19 @@
+export default function FloatingWhatsApp() {
+  return (
+    <a
+      href="https://api.whatsapp.com/send?phone=11967586911"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Fale conosco no WhatsApp"
+      className="fixed bottom-5 right-4 z-50 flex h-12 w-12 items-center justify-center rounded-full bg-[#25D366] shadow-[0_10px_30px_rgba(0,0,0,0.18)] transition hover:scale-105 focus:outline-none focus:ring-2 focus:ring-custom-text-secondary sm:bottom-6 sm:right-6 sm:h-14 sm:w-14"
+    >
+      <svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 32 32" fill="none" className="sm:h-[30px] sm:w-[30px]">
+        <circle cx="16" cy="16" r="16" fill="#25D366" />
+        <path
+          d="M23.472 19.339c-.355-.177-2.104-1.037-2.43-1.155-.326-.119-.563-.177-.8.177-.237.355-.914 1.155-1.122 1.392-.207.237-.414.266-.77.089-.355-.178-1.5-.553-2.86-1.763-1.057-.944-1.77-2.108-1.98-2.463-.207-.355-.022-.547.155-.724.159-.158.355-.414.533-.622.178-.207.237-.355.355-.592.119-.237.06-.444-.03-.622-.089-.178-.8-1.924-1.096-2.637-.289-.693-.583-.599-.8-.61-.207-.009-.444-.011-.681-.011-.237 0-.622.089-.948.444-.326.355-1.24 1.211-1.24 2.949 0 1.738 1.27 3.417 1.447 3.654.178.237 2.5 3.82 6.063 5.207.849.292 1.51.466 2.027.596.851.204 1.627.175 2.24.106.683-.077 2.104-.859 2.403-1.689.296-.83.296-1.541.207-1.689-.089-.148-.326-.237-.681-.414z"
+          fill="#fff"
+        />
+      </svg>
+    </a>
+  )
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -5,8 +5,7 @@ import { blogSerif } from "@/lib/blog-design"
 
 export default function Footer() {
   return (
-    <>
-      <footer className="relative border-t border-custom-text-primary/12 bg-custom-bg-secondary text-custom-text-secondary">
+    <footer className="relative border-t border-custom-text-primary/12 bg-custom-bg-secondary text-custom-text-secondary">
         <div className="container mx-auto px-4 py-12 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-7xl">
             <div className="grid gap-10 lg:grid-cols-[1.2fr_0.8fr_0.8fr]">
@@ -107,22 +106,5 @@ export default function Footer() {
           </div>
         </div>
       </footer>
-
-      <a
-        href="https://api.whatsapp.com/send?phone=11967586911"
-        target="_blank"
-        rel="noopener noreferrer"
-        aria-label="Fale conosco no WhatsApp"
-        className="fixed bottom-6 right-6 z-50 flex h-14 w-14 items-center justify-center rounded-full bg-[#25D366] shadow-[0_10px_30px_rgba(0,0,0,0.18)] transition hover:scale-105 focus:outline-none focus:ring-2 focus:ring-custom-text-secondary"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 32 32" fill="none">
-          <circle cx="16" cy="16" r="16" fill="#25D366" />
-          <path
-            d="M23.472 19.339c-.355-.177-2.104-1.037-2.43-1.155-.326-.119-.563-.177-.8.177-.237.355-.914 1.155-1.122 1.392-.207.237-.414.266-.77.089-.355-.178-1.5-.553-2.86-1.763-1.057-.944-1.77-2.108-1.98-2.463-.207-.355-.022-.547.155-.724.159-.158.355-.414.533-.622.178-.207.237-.355.355-.592.119-.237.06-.444-.03-.622-.089-.178-.8-1.924-1.096-2.637-.289-.693-.583-.599-.8-.61-.207-.009-.444-.011-.681-.011-.237 0-.622.089-.948.444-.326.355-1.24 1.211-1.24 2.949 0 1.738 1.27 3.417 1.447 3.654.178.237 2.5 3.82 6.063 5.207.849.292 1.51.466 2.027.596.851.204 1.627.175 2.24.106.683-.077 2.104-.859 2.403-1.689.296-.83.296-1.541.207-1.689-.089-.148-.326-.237-.681-.414z"
-            fill="#fff"
-          />
-        </svg>
-      </a>
-    </>
   )
 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -21,14 +21,14 @@ export default function Header() {
   return (
     <header className="fixed inset-x-0 top-0 z-50">
       <div className="container mx-auto px-4 pt-4 sm:px-6 lg:px-8">
-        <div className="home-panel flex h-20 items-center justify-between rounded-full px-4 sm:px-6">
-          <Link href="/" className="flex items-center gap-3" aria-label="Lucimeire Xavier Advocacia">
+        <div className="home-panel flex h-16 items-center justify-between rounded-full px-4 sm:h-20 sm:px-6">
+          <Link href="/" className="flex items-center gap-3 pr-3" aria-label="Lucimeire Xavier Advocacia">
             <Image
               src="/images/logo.png"
               alt="Lucimeire Xavier Advocacia"
               width={200}
               height={80}
-              className="h-11 w-auto sm:h-12"
+              className="h-8 w-auto sm:h-12"
               priority
             />
           </Link>
@@ -60,8 +60,8 @@ export default function Header() {
 
           <Sheet open={isOpen} onOpenChange={setIsOpen}>
             <SheetTrigger asChild>
-              <Button variant="ghost" size="icon" className="text-custom-text-secondary md:hidden">
-                <Menu className="h-6 w-6" />
+              <Button variant="ghost" size="icon" className="h-10 w-10 text-custom-text-secondary md:hidden">
+                <Menu className="h-5 w-5" />
               </Button>
             </SheetTrigger>
             <SheetContent side="right" className="border-custom-text-primary/12 bg-custom-bg-secondary text-custom-text-secondary">

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -17,11 +17,11 @@ export default function Hero() {
 
               <div className="space-y-6">
                 <h1 className={`${blogSerif.className} max-w-5xl text-5xl leading-[0.95] sm:text-6xl lg:text-7xl`}>
-                  Estratégia tributária para empresas que não podem decidir no escuro.
+                  Advogada tributarista em São Bernardo do Campo para empresas que precisam decidir com mais clareza.
                 </h1>
                 <p className="max-w-2xl text-lg leading-8 text-custom-text-primary/88 sm:text-xl">
-                  Planejamento, defesa fiscal e consultoria preventiva com leitura jurídica conectada ao caixa,
-                  ao passivo e ao risco real da operação.
+                  Planejamento tributário, execução fiscal e consultoria fiscal preventiva com leitura jurídica
+                  conectada ao caixa, ao passivo e ao risco real da operação.
                 </p>
               </div>
 

--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -9,17 +9,19 @@ export default function Hero() {
       <div className="container mx-auto px-4 sm:px-6 lg:px-8">
         <div className="mx-auto max-w-7xl">
           <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr] lg:items-end">
-            <div className="space-y-8 rounded-[2rem] border border-custom-text-primary/14 bg-gradient-to-br from-white/8 via-white/3 to-transparent p-7 shadow-[0_28px_100px_rgba(0,0,0,0.26)] backdrop-blur-sm sm:p-10 lg:p-12">
+            <div className="space-y-7 rounded-[1.8rem] border border-custom-text-primary/14 bg-gradient-to-br from-white/8 via-white/3 to-transparent p-5 shadow-[0_28px_100px_rgba(0,0,0,0.26)] backdrop-blur-sm sm:space-y-8 sm:rounded-[2rem] sm:p-10 lg:p-12">
               <div className="section-kicker">
                 <Sparkles className="h-3.5 w-3.5" />
                 Boutique jurídica tributária
               </div>
 
               <div className="space-y-6">
-                <h1 className={`${blogSerif.className} max-w-5xl text-5xl leading-[0.95] sm:text-6xl lg:text-7xl`}>
+                <h1
+                  className={`${blogSerif.className} max-w-5xl text-[3rem] leading-[0.97] tracking-[-0.035em] sm:text-6xl lg:text-7xl`}
+                >
                   Advogada tributarista em São Bernardo do Campo para empresas que precisam decidir com mais clareza.
                 </h1>
-                <p className="max-w-2xl text-lg leading-8 text-custom-text-primary/88 sm:text-xl">
+                <p className="max-w-2xl text-base leading-7 text-custom-text-primary/88 sm:text-xl sm:leading-8">
                   Planejamento tributário, execução fiscal e consultoria fiscal preventiva com leitura jurídica
                   conectada ao caixa, ao passivo e ao risco real da operação.
                 </p>
@@ -44,7 +46,7 @@ export default function Hero() {
               </div>
 
               <div className="flex flex-col gap-4 sm:flex-row">
-                <Button asChild size="lg" className="rounded-full bg-custom-text-primary px-8 text-custom-bg-primary hover:bg-custom-text-secondary">
+                <Button asChild size="lg" className="rounded-full bg-custom-text-primary px-6 text-custom-bg-primary hover:bg-custom-text-secondary sm:px-8">
                   <Link href="#contact">
                     Solicitar análise tributária
                     <ArrowRight className="h-5 w-5" />
@@ -62,12 +64,12 @@ export default function Hero() {
             </div>
 
             <div className="grid gap-5">
-              <div className="home-paper rounded-[2rem] p-7 text-slate-900 sm:p-8">
+              <div className="home-paper rounded-[1.8rem] p-5 text-slate-900 sm:rounded-[2rem] sm:p-8">
                 <p className="text-xs uppercase tracking-[0.26em] text-[#7f5b39]">Como a atuação entra</p>
-                <h2 className={`${blogSerif.className} mt-4 text-4xl leading-tight sm:text-5xl`}>
+                <h2 className={`${blogSerif.className} mt-4 text-[2.35rem] leading-[1.02] sm:text-5xl`}>
                   Diagnóstico técnico antes que o problema vire custo permanente.
                 </h2>
-                <p className="mt-4 text-base leading-8 text-slate-700">
+                <p className="mt-4 text-[0.98rem] leading-7 text-slate-700 sm:text-base sm:leading-8">
                   A proposta do escritório é organizar decisão, não apenas reagir ao litígio. O trabalho começa com
                   leitura da operação, da exposição tributária e do melhor caminho de resposta.
                 </p>

--- a/components/scroll-to-top.tsx
+++ b/components/scroll-to-top.tsx
@@ -31,10 +31,10 @@ export default function ScrollToTop() {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="fixed bottom-6 left-6 z-50 flex items-center justify-center w-12 h-12 bg-custom-text-primary/80 hover:bg-custom-text-primary text-custom-bg-secondary rounded-full shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-110 hover:-translate-y-1 group"
+          className="group fixed bottom-20 left-4 z-40 flex h-11 w-11 items-center justify-center rounded-full bg-custom-text-primary/80 text-custom-bg-secondary shadow-lg transition-all duration-300 hover:-translate-y-1 hover:scale-110 hover:bg-custom-text-primary hover:shadow-xl sm:bottom-6 sm:left-6 sm:z-50 sm:h-12 sm:w-12"
           aria-label="Voltar ao topo"
         >
-          <ChevronUp className="w-5 h-5 group-hover:-translate-y-0.5 transition-transform duration-300" />
+          <ChevronUp className="h-5 w-5 transition-transform duration-300 group-hover:-translate-y-0.5" />
         </button>
       )}
     </>

--- a/components/services.tsx
+++ b/components/services.tsx
@@ -100,11 +100,11 @@ export default function Services() {
               </div>
               <div>
                 <h2 className={`${blogSerif.className} max-w-4xl text-5xl leading-[0.96] text-custom-text-secondary sm:text-6xl`}>
-                  Direito tributário como núcleo, com áreas complementares orbitando a operação.
+                  Direito tributário como núcleo da atuação, com apoio jurídico complementar para a operação.
                 </h2>
                 <p className="mt-6 max-w-3xl text-lg leading-8 text-custom-text-primary/84">
-                  A home deixa isso explícito: o escritório não disputa atenção com seis serviços equivalentes. O eixo
-                  principal é tributário; as demais áreas entram quando ajudam a resolver o caso com mais completude.
+                  O escritório concentra sua proposta em planejamento tributário, execução fiscal e consultoria fiscal.
+                  As demais áreas entram quando ajudam a resolver o caso com mais contexto e menor risco.
                 </p>
               </div>
             </div>

--- a/content/blog/como-suspender-execucao-fiscal-para-empresa.mdx
+++ b/content/blog/como-suspender-execucao-fiscal-para-empresa.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Como Suspender Execução Fiscal da Empresa: O Que Avaliar Antes de Decidir"
+title: "Como Suspender Execução Fiscal da Empresa: Medidas Possíveis e O Que Avaliar"
 excerpt: "Entenda em quais cenários a empresa pode avaliar medidas para suspender execução fiscal e por que a estratégia depende de análise técnica do passivo."
 date: "2026-03-05"
 category: "Direito Tributário"
@@ -7,7 +7,7 @@ author: "Dra. Lucimeire Xavier"
 published: true
 ---
 
-# Como Suspender Execução Fiscal da Empresa: O Que Avaliar Antes de Decidir
+# Como Suspender Execução Fiscal da Empresa: Medidas Possíveis e O Que Avaliar
 
 Quando a empresa recebe uma execução fiscal, a primeira reação costuma ser procurar uma forma de parar a cobrança o mais rápido possível. Essa urgência é compreensível, mas o caminho não pode ser escolhido no escuro.
 
@@ -92,15 +92,15 @@ Esse diagnóstico evita medida precipitada e ajuda a definir se a prioridade é 
 
 ## Leia também
 
-- [Execução Fiscal para Empresas: Estratégias de Defesa e Primeiros Passos](/blog/defesa-em-execucao-fiscal-estrategias-para-empresas)
-- [O Que Fazer ao Receber Cobrança Tributária na Empresa: Primeiros Passos](/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa)
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Execução Fiscal para Empresas: O Que Fazer nos Primeiros Dias](/blog/defesa-em-execucao-fiscal-estrategias-para-empresas)
+- [Cobrança Tributária na Empresa: O Que Fazer Antes de Pagar ou Parcelar](/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
 
 ## Conclusão
 
 Suspender execução fiscal pode fazer parte da estratégia, mas só quando o caso é lido com técnica e contexto. A empresa precisa entender o estágio da cobrança, os efeitos da medida e o impacto financeiro da decisão.
 
-Se sua empresa está em execução fiscal ou sob risco de constrição, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se sua empresa está em execução fiscal ou sob risco de constrição, vale entender [o que fazer ao receber cobrança tributária na empresa](/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/compliance-tributario-como-evitar-autuacoes.mdx
+++ b/content/blog/compliance-tributario-como-evitar-autuacoes.mdx
@@ -134,10 +134,20 @@ Um caminho objetivo para começar:
 4. Criar procedimentos e checklists
 5. Revisar periodicamente com suporte especializado
 
+## Perguntas frequentes sobre compliance tributário
+
+### Compliance tributário serve apenas para empresas grandes?
+
+Não. Empresas de diferentes portes podem estruturar rotinas fiscais para reduzir erro, melhorar previsibilidade e responder melhor a fiscalizações.
+
+### Compliance tributário substitui consultoria fiscal?
+
+Não. O compliance organiza processo e rotina. A [consultoria fiscal para empresas](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita) entra para revisar risco, interpretar impactos e orientar decisões mais estratégicas.
+
 ## Leia também
 
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
-- [Planejamento Tributário para Empresas: Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
 - [Simples Nacional, Lucro Presumido e Lucro Real: Como Avaliar o Regime Tributário](/blog/simples-nacional-lucro-presumido-e-lucro-real-como-avaliar-o-regime-tributario)
 
 ## Conclusão
@@ -146,7 +156,7 @@ Compliance tributário não é custo de burocracia. É uma ferramenta de **gest�
 
 Empresas que estruturam seus processos fiscais tendem a reduzir erros, responder melhor a fiscalizações e tomar decisões com mais segurança.
 
-Se você quer estruturar rotinas fiscais com mais segurança jurídica, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se você quer estruturar rotinas fiscais com mais segurança jurídica, vale revisar também nosso conteúdo sobre [planejamento tributário para empresas](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita.mdx
+++ b/content/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita"
+title: "Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação"
 excerpt: "Entenda quando a consultoria fiscal ajuda a prevenir autuações, reduzir passivos tributários e dar mais previsibilidade para a empresa."
 date: "2026-02-26"
 category: "Direito Tributário"
@@ -7,7 +7,7 @@ author: "Dra. Lucimeire Xavier"
 published: true
 ---
 
-# Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita
+# Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação
 
 Muitas empresas só procuram consultoria fiscal quando já existe autuação, cobrança, inconsistência em obrigações acessórias ou pressão no caixa causada por erro tributário. Quando isso acontece, a margem de decisão costuma ser menor e a correção tende a sair mais cara.
 
@@ -139,14 +139,14 @@ Em outras palavras, a consultoria fiscal tende a ser mais eficiente quando entra
 ## Leia também
 
 - [Compliance Tributário: Como Evitar Autuações na Empresa](/blog/compliance-tributario-como-evitar-autuacoes)
-- [Planejamento Tributário para Empresas: Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
+- [Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
 - [Simples Nacional, Lucro Presumido e Lucro Real: Como Avaliar o Regime Tributário](/blog/simples-nacional-lucro-presumido-e-lucro-real-como-avaliar-o-regime-tributario)
 
 ## Conclusão
 
 Consultoria fiscal para empresas não é apenas uma resposta a problemas. É uma ferramenta de organização, prevenção e segurança para decisões com impacto tributário.
 
-Se sua empresa precisa revisar riscos, rotinas e estratégias, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se sua empresa precisa revisar riscos, rotinas e estratégias, vale comparar isso com um [planejamento tributário para empresas](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/defesa-em-execucao-fiscal-estrategias-para-empresas.mdx
+++ b/content/blog/defesa-em-execucao-fiscal-estrategias-para-empresas.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Execução Fiscal para Empresas: Estratégias de Defesa e Primeiros Passos"
-excerpt: "Entenda o que fazer nos primeiros dias após a citação em execução fiscal e quais estratégias podem proteger a operação da empresa."
+title: "Execução Fiscal para Empresas: O Que Fazer nos Primeiros Dias"
+excerpt: "Entenda o que fazer nos primeiros dias após a citação em execução fiscal e quais medidas podem proteger a operação da empresa."
 date: "2026-02-26"
 category: "Direito Tributário"
 author: "Dra. Lucimeire Xavier"
 published: true
 ---
 
-# Execução Fiscal para Empresas: Estratégias de Defesa e Primeiros Passos
+# Execução Fiscal para Empresas: O Que Fazer nos Primeiros Dias
 
 Receber uma cobrança em execução fiscal costuma gerar insegurança e impacto imediato na operação da empresa. Dependendo do caso, pode haver risco de:
 
@@ -112,9 +112,9 @@ O ideal é buscar orientação em Direito Tributário assim que houver:
 
 ## Leia também
 
-- [Planejamento Tributário para Empresas: Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
-- [Recuperação de Créditos Tributários: Quem Pode Recuperar e Quais Cuidados Tomar](/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados)
+- [Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Recuperação de Créditos Tributários para Empresas: Quem Pode Avaliar](/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados)
 
 ## Conclusão
 
@@ -122,7 +122,7 @@ A execução fiscal não deve ser tratada apenas como uma cobrança. Ela pode ex
 
 Uma atuação estratégica permite avaliar defesa, negociação e medidas preventivas para proteger a empresa e organizar o passivo com mais segurança.
 
-Se sua empresa foi citada ou está com risco de cobrança, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e entre em contato pelo [formulário](/#contact) para avaliação do caso.
+Se sua empresa foi citada ou está com risco de cobrança, vale entender também [como suspender execução fiscal da empresa](/blog/como-suspender-execucao-fiscal-para-empresa), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e entrar em contato pelo [formulário](/#contact) para avaliação do caso.
 
 ---
 

--- a/content/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa.mdx
+++ b/content/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa.mdx
@@ -1,5 +1,5 @@
 ---
-title: "O Que Fazer ao Receber Cobrança Tributária na Empresa: Primeiros Passos"
+title: "Cobrança Tributária na Empresa: O Que Fazer Antes de Pagar ou Parcelar"
 excerpt: "Veja quais são os primeiros passos após receber uma cobrança tributária na empresa e por que agir cedo reduz risco de bloqueio, autuação e decisões precipitadas."
 date: "2026-03-05"
 category: "Direito Tributário"
@@ -7,7 +7,7 @@ author: "Dra. Lucimeire Xavier"
 published: true
 ---
 
-# O Que Fazer ao Receber Cobrança Tributária na Empresa: Primeiros Passos
+# Cobrança Tributária na Empresa: O Que Fazer Antes de Pagar ou Parcelar
 
 Receber uma cobrança tributária costuma gerar duas reações ruins: paralisar ou correr para pagar sem análise. Nenhuma das duas é a melhor saída.
 
@@ -115,15 +115,15 @@ Essa abordagem ajuda a diferenciar um problema pontual de um passivo estrutural.
 
 ## Leia também
 
-- [Como Suspender Execução Fiscal da Empresa: O Que Avaliar Antes de Decidir](/blog/como-suspender-execucao-fiscal-para-empresa)
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Como Suspender Execução Fiscal da Empresa: Medidas Possíveis e O Que Avaliar](/blog/como-suspender-execucao-fiscal-para-empresa)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
 - [Quais Documentos Separar Antes de uma Consultoria Tributária](/blog/quais-documentos-separar-antes-de-uma-consultoria-tributaria)
 
 ## Conclusão
 
 Receber cobrança tributária não significa que a melhor decisão seja pagar imediatamente. Significa que a empresa precisa organizar informação, entender o estágio do débito e escolher a resposta com critério.
 
-Se sua empresa recebeu cobrança, notificação ou está sob risco de execução, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se sua empresa recebeu cobrança, notificação ou está sob risco de execução, vale ver também [como suspender execução fiscal da empresa](/blog/como-suspender-execucao-fiscal-para-empresa), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/parcelamento-de-divida-fiscal-para-empresas-quando-vale-a-pena.mdx
+++ b/content/blog/parcelamento-de-divida-fiscal-para-empresas-quando-vale-a-pena.mdx
@@ -101,17 +101,27 @@ Antes de tomar a decisão, vale responder:
 
 Essas respostas ajudam a diferenciar um parcelamento estratégico de uma adesão feita apenas para apagar incêndio.
 
+## Perguntas frequentes sobre parcelamento de dívida fiscal
+
+### Parcelamento sempre é a melhor saída para dívida fiscal?
+
+Não. Em alguns casos, o parcelamento ajuda a reorganizar o passivo. Em outros, pode travar caixa sem resolver a origem do problema ou sem ser a medida juridicamente mais eficiente.
+
+### Parcelamento elimina a necessidade de análise tributária?
+
+Não. Antes de aderir, a empresa precisa entender o valor cobrado, o impacto financeiro e se existem alternativas ligadas a [execução fiscal para empresas](/blog/defesa-em-execucao-fiscal-estrategias-para-empresas) ou revisão técnica do débito.
+
 ## Leia também
 
-- [Planejamento Tributário para Empresas: Como Reduzir Riscos e Ganhar Previsibilidade](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
-- [Recuperação de Créditos Tributários: Quem Pode Recuperar e Quais Cuidados Tomar](/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados)
+- [Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
+- [Recuperação de Créditos Tributários para Empresas: Quem Pode Avaliar](/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados)
 - [Compliance Tributário para Empresas: Como Estruturar Rotinas e Evitar Autuações](/blog/compliance-tributario-como-evitar-autuacoes)
 
 ## Conclusão
 
 O parcelamento de dívida fiscal pode ser uma ferramenta útil, desde que a adesão seja feita com análise de risco, viabilidade financeira e estratégia jurídica adequada.
 
-Se sua empresa precisa avaliar esse caminho com segurança, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se sua empresa precisa avaliar esse caminho com segurança, vale comparar com [o que fazer ao receber cobrança tributária na empresa](/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/planejamento-tributario-para-empresas-como-reduzir-riscos.mdx
+++ b/content/blog/planejamento-tributario-para-empresas-como-reduzir-riscos.mdx
@@ -1,13 +1,13 @@
 ---
-title: "Planejamento Tributário para Empresas: Como Reduzir Riscos e Ganhar Previsibilidade"
-excerpt: "Saiba como o planejamento tributário ajuda empresas a reduzir riscos fiscais, organizar a carga tributária e decidir com mais previsibilidade."
+title: "Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos"
+excerpt: "Entenda quando revisar o planejamento tributário da empresa e como isso ajuda a reduzir riscos fiscais e ganhar previsibilidade."
 date: "2026-02-26"
 category: "Direito Tributário"
 author: "Dra. Lucimeire Xavier"
 published: true
 ---
 
-# Planejamento Tributário para Empresas: Como Reduzir Riscos e Ganhar Previsibilidade
+# Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos
 
 O planejamento tributário é uma estratégia essencial para empresas que desejam **reduzir riscos fiscais**, melhorar a previsibilidade financeira e pagar tributos de forma correta e segura.
 
@@ -115,14 +115,14 @@ Esse trabalho é especialmente importante para empresas que querem crescer com s
 ## Leia também
 
 - [Simples Nacional, Lucro Presumido e Lucro Real: Como Avaliar o Regime Tributário](/blog/simples-nacional-lucro-presumido-e-lucro-real-como-avaliar-o-regime-tributario)
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
 - [Compliance Tributário: Como Evitar Autuações na Empresa](/blog/compliance-tributario-como-evitar-autuacoes)
 
 ## Conclusão
 
 Planejamento tributário é uma ferramenta de **proteção patrimonial e gestão de risco**, não apenas de economia fiscal. Quanto antes a empresa estruturar essa rotina, menor tende a ser a exposição a problemas futuros.
 
-Se você quer entender como aplicar isso na realidade do seu negócio, conheça nossa área de atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se você quer entender como aplicar isso na realidade do seu negócio, vale comparar com nossa visão sobre [consultoria fiscal para empresas](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita), conhecer a área de [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/quais-documentos-separar-antes-de-uma-consultoria-tributaria.mdx
+++ b/content/blog/quais-documentos-separar-antes-de-uma-consultoria-tributaria.mdx
@@ -134,17 +134,27 @@ Se a empresa quiser ganhar tempo, vale chegar à consulta com:
 
 Isso acelera a conversa e ajuda a transformar a reunião em análise prática, não apenas em levantamento inicial.
 
+## Perguntas frequentes antes da consultoria tributária
+
+### Preciso levar todos os documentos da empresa para a primeira reunião?
+
+Não. O ideal é separar os documentos diretamente ligados ao problema principal, especialmente quando houver cobrança, execução fiscal, dúvida sobre regime ou passivo relevante.
+
+### Vale buscar consultoria mesmo sem autuação formal?
+
+Sim. Muitas empresas procuram apoio justamente para agir antes da autuação, revisar risco e organizar decisão com mais clareza.
+
 ## Leia também
 
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
 - [Compliance Tributário para Empresas: Como Estruturar Rotinas e Evitar Autuações](/blog/compliance-tributario-como-evitar-autuacoes)
-- [Planejamento Tributário para Empresas: Como Reduzir Riscos e Ganhar Previsibilidade](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
+- [Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
 
 ## Conclusão
 
 Organizar documentos antes de uma consultoria tributária melhora a qualidade do diagnóstico e reduz perda de tempo em casos que exigem resposta rápida.
 
-Se sua empresa precisa avaliar risco fiscal, passivo, cobrança ou oportunidade de revisão com mais clareza, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se sua empresa precisa avaliar risco fiscal, passivo, cobrança ou oportunidade de revisão com mais clareza, vale ver também [o que fazer ao receber cobrança tributária na empresa](/blog/o-que-fazer-ao-receber-cobranca-tributaria-na-empresa), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/content/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados.mdx
+++ b/content/blog/recuperacao-de-creditos-tributarios-quem-pode-recuperar-e-cuidados.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Recuperação de Créditos Tributários: Quem Pode Recuperar e Quais Cuidados Tomar"
+title: "Recuperação de Créditos Tributários para Empresas: Quem Pode Avaliar"
 excerpt: "Saiba quando a recuperação de créditos tributários pode ser analisada, quem costuma ter essa oportunidade e quais cuidados reduzem riscos."
 date: "2026-02-26"
 category: "Direito Tributário"
@@ -7,7 +7,7 @@ author: "Dra. Lucimeire Xavier"
 published: true
 ---
 
-# Recuperação de Créditos Tributários: Quem Pode Recuperar e Quais Cuidados Tomar
+# Recuperação de Créditos Tributários para Empresas: Quem Pode Avaliar
 
 A recuperação de créditos tributários é um tema cada vez mais relevante para empresas que buscam melhorar fluxo de caixa e corrigir pagamentos indevidos. No entanto, o assunto exige cuidado técnico para evitar soluções apressadas e riscos futuros.
 
@@ -126,15 +126,15 @@ Também faz sentido buscar apoio quando existe percepção de que a empresa “p
 
 ## Leia também
 
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
-- [Defesa em Execução Fiscal: Estratégias para Empresas](/blog/defesa-em-execucao-fiscal-estrategias-para-empresas)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Execução Fiscal para Empresas: O Que Fazer nos Primeiros Dias](/blog/defesa-em-execucao-fiscal-estrategias-para-empresas)
 - [Compliance Tributário: Como Evitar Autuações na Empresa](/blog/compliance-tributario-como-evitar-autuacoes)
 
 ## Conclusão
 
 Recuperação de créditos tributários pode ser uma oportunidade legítima para empresas, desde que conduzida com análise técnica, documentação adequada e estratégia jurídica consistente.
 
-Se sua empresa quer avaliar esse tema com segurança, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e entre em contato pelo [formulário](/#contact).
+Se sua empresa quer avaliar esse tema com segurança, veja também quando a [consultoria fiscal para empresas](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita) faz sentido, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e entre em contato pelo [formulário](/#contact).
 
 ---
 

--- a/content/blog/simples-nacional-lucro-presumido-e-lucro-real-como-avaliar-o-regime-tributario.mdx
+++ b/content/blog/simples-nacional-lucro-presumido-e-lucro-real-como-avaliar-o-regime-tributario.mdx
@@ -93,17 +93,27 @@ A escolha do regime faz parte do **planejamento tributário** e deve ser acompan
 
 Se a empresa também enfrenta passivos ou cobranças, a análise pode exigir atuação em Direito Tributário com estratégia contenciosa e preventiva integrada.
 
+## Perguntas frequentes sobre regime tributário
+
+### Existe um regime tributário melhor para toda empresa?
+
+Não. A melhor escolha depende de faturamento, margem, tipo de operação, estrutura de custos, obrigações acessórias e nível de risco fiscal.
+
+### Quando vale revisar o regime tributário?
+
+Sempre que houver crescimento, mudança de atividade, expansão operacional ou sinais de que a carga tributária atual não acompanha mais a realidade do negócio.
+
 ## Leia também
 
-- [Planejamento Tributário para Empresas: Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
-- [Consultoria Fiscal para Empresas: Quando Contratar e Quais Problemas Evita](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
+- [Planejamento Tributário para Empresas: Quando Revisar e Como Reduzir Riscos](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos)
+- [Consultoria Fiscal para Empresas: Quando Contratar Antes da Autuação](/blog/consultoria-fiscal-para-empresas-quando-contratar-e-quais-problemas-evita)
 - [Compliance Tributário: Como Evitar Autuações na Empresa](/blog/compliance-tributario-como-evitar-autuacoes)
 
 ## Conclusão
 
 Não existe regime tributário “melhor” de forma genérica. Existe a alternativa mais adequada para a realidade e os objetivos da empresa, com base em análise técnica.
 
-Se sua empresa precisa revisar enquadramento e riscos fiscais, conheça nossa atuação em [Direito Tributário](/areas/direito-tributario) e fale conosco pelo [formulário de contato](/#contact).
+Se sua empresa precisa revisar enquadramento e riscos fiscais, vale aprofundar também em [planejamento tributário para empresas](/blog/planejamento-tributario-para-empresas-como-reduzir-riscos), conhecer nossa atuação em [Direito Tributário](/areas/direito-tributario) e falar conosco pelo [formulário de contato](/#contact).
 
 ---
 

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -6,7 +6,7 @@ export const SEO = {
   locale: "pt_BR",
   defaultTitle: "Advogada Tributarista em São Bernardo do Campo",
   defaultDescription:
-    "Lucimeire Xavier Advocacia oferece assessoria em Direito Tributário para empresas e profissionais em São Bernardo do Campo, com foco em planejamento tributário, execuções fiscais e consultoria fiscal.",
+    "Assessoria em Direito Tributário para empresas e profissionais em São Bernardo do Campo, com foco em planejamento tributário, execução fiscal, consultoria fiscal e prevenção de riscos tributários.",
   phoneDisplay: "(11) 96758-6911",
   phoneIntl: "+55-11-96758-6911",
   email: "contato@lucimeirexavieradvocacia.adv.br",
@@ -94,12 +94,14 @@ const areaPages: Record<
   { title: string; description: string; keywords: string[] }
 > = {
   "direito-tributario": {
-    title: "Direito Tributário para Empresas e Profissionais",
+    title: "Advogada Tributarista em São Bernardo do Campo",
     description:
-      "Assessoria em Direito Tributário em São Bernardo do Campo com foco em planejamento tributário, consultoria fiscal, execuções fiscais e contencioso tributário.",
+      "Advogada tributarista em São Bernardo do Campo para empresas e profissionais. Atuação em planejamento tributário, consultoria fiscal, execução fiscal e contencioso tributário.",
     keywords: [
       "direito tributário",
       "advogada tributarista",
+      "advogada tributarista são bernardo do campo",
+      "advogado tributário são bernardo do campo",
       "planejamento tributário",
       "execução fiscal",
       "consultoria fiscal",
@@ -107,40 +109,40 @@ const areaPages: Record<
     ],
   },
   "direito-empresarial": {
-    title: "Direito Empresarial e Contratos Comerciais",
+    title: "Direito Empresarial em São Bernardo do Campo",
     description:
-      "Consultoria em Direito Empresarial para empresas, com apoio em contratos comerciais, compliance e estruturação jurídica de negócios em São Bernardo do Campo.",
-    keywords: ["direito empresarial", "contratos comerciais", "compliance empresarial"],
+      "Consultoria em Direito Empresarial para empresas em São Bernardo do Campo, com apoio em contratos comerciais, compliance, estrutura societária e decisões com reflexo tributário.",
+    keywords: ["direito empresarial", "advogado empresarial são bernardo do campo", "contratos comerciais", "compliance empresarial"],
   },
   "direito-civil": {
-    title: "Direito Civil e Contratos",
+    title: "Direito Civil e Contratos em São Bernardo do Campo",
     description:
-      "Atuação em Direito Civil com suporte em contratos, responsabilidade civil e proteção de direitos pessoais, com atendimento em São Bernardo do Campo.",
-    keywords: ["direito civil", "contratos civis", "responsabilidade civil"],
+      "Atuação em Direito Civil com suporte em contratos, responsabilidade civil e proteção patrimonial, com atendimento em São Bernardo do Campo.",
+    keywords: ["direito civil", "advogado civil são bernardo do campo", "contratos civis", "responsabilidade civil"],
   },
   "direito-imobiliario": {
-    title: "Direito Imobiliário para Compra, Venda e Locação",
+    title: "Direito Imobiliário em São Bernardo do Campo",
     description:
-      "Assessoria em Direito Imobiliário para compra e venda, locações e regularização de imóveis, com atendimento jurídico em São Bernardo do Campo.",
-    keywords: ["direito imobiliário", "compra e venda de imóveis", "locação", "regularização"],
+      "Assessoria em Direito Imobiliário para compra e venda, locações e regularização de imóveis em São Bernardo do Campo, com atenção a risco patrimonial e impacto tributário.",
+    keywords: ["direito imobiliário", "advogado imobiliário são bernardo do campo", "compra e venda de imóveis", "locação", "regularização"],
   },
   "direito-trabalhista": {
-    title: "Direito Trabalhista e Consultoria Preventiva",
+    title: "Direito Trabalhista em São Bernardo do Campo",
     description:
-      "Atendimento em Direito Trabalhista para rescisões, ações trabalhistas e consultoria preventiva para empresas e trabalhadores em São Bernardo do Campo.",
-    keywords: ["direito trabalhista", "ações trabalhistas", "consultoria trabalhista"],
+      "Atendimento em Direito Trabalhista para rescisões, ações trabalhistas e consultoria preventiva em São Bernardo do Campo, com foco em redução de passivo e organização da operação.",
+    keywords: ["direito trabalhista", "advogado trabalhista são bernardo do campo", "ações trabalhistas", "consultoria trabalhista"],
   },
   "direito-processual": {
-    title: "Direito Processual e Representação em Ações",
+    title: "Direito Processual e Estratégia Processual",
     description:
-      "Representação em processos judiciais e administrativos, com foco em estratégia processual, recursos e execuções em São Bernardo do Campo.",
-    keywords: ["direito processual", "ações judiciais", "recursos", "execuções"],
+      "Representação em processos judiciais e administrativos, com foco em estratégia processual, recursos, execuções e disputas com impacto tributário em São Bernardo do Campo.",
+    keywords: ["direito processual", "advogado processual são bernardo do campo", "ações judiciais", "recursos", "execuções"],
   },
   "consultoria-juridica": {
-    title: "Consultoria Jurídica Preventiva e Estratégica",
+    title: "Consultoria Jurídica Preventiva em São Bernardo do Campo",
     description:
-      "Consultoria jurídica preventiva para pessoas físicas e jurídicas, com pareceres, due diligence e suporte estratégico em São Bernardo do Campo.",
-    keywords: ["consultoria jurídica", "parecer jurídico", "due diligence"],
+      "Consultoria jurídica preventiva para empresas e profissionais, com pareceres, due diligence e suporte estratégico em São Bernardo do Campo.",
+    keywords: ["consultoria jurídica", "consultoria jurídica empresarial", "parecer jurídico", "due diligence"],
   },
 }
 
@@ -202,6 +204,33 @@ export function buildTaxServiceSchema() {
   }
 }
 
+export function buildAreaServiceSchema(input: {
+  slug: string
+  serviceType: string
+  name: string
+  description: string
+}) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Service",
+    "@id": `${SEO.siteUrl}/areas/${input.slug}#service`,
+    serviceType: input.serviceType,
+    name: input.name,
+    provider: {
+      "@type": "LegalService",
+      name: SEO.siteName,
+      url: SEO.siteUrl,
+    },
+    areaServed: ["São Bernardo do Campo", "São Paulo", "Brasil"],
+    offers: {
+      "@type": "Offer",
+      availability: "https://schema.org/InStock",
+      url: `${SEO.siteUrl}/areas/${input.slug}`,
+    },
+    description: input.description,
+  }
+}
+
 export function buildBlogPostingSchema(input: {
   title: string
   description: string
@@ -230,5 +259,25 @@ export function buildBlogPostingSchema(input: {
     },
     mainEntityOfPage: canonicalUrl(`/blog/${input.slug}`),
     url: canonicalUrl(`/blog/${input.slug}`),
+  }
+}
+
+export function buildFaqSchema(
+  questions: Array<{
+    question: string
+    answer: string
+  }>
+) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: questions.map((item) => ({
+      "@type": "Question",
+      name: item.question,
+      acceptedAnswer: {
+        "@type": "Answer",
+        text: item.answer,
+      },
+    })),
   }
 }


### PR DESCRIPTION
## Summary
- refine homepage, blog, and area page microcopy for stronger local and commercial SEO intent
- add FAQ and service structured data to area pages
- strengthen internal linking across area pages and key tributary blog posts, including CTR-oriented title updates

## Testing
- npm run lint
- Next.js MCP runtime check reported no errors